### PR TITLE
Implement configurable hotkey feature

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,106 @@
-use crate::hotkey::Hotkey;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Read, Result, Write},
+    path::PathBuf,
+};
+
+use crate::{hotkey::Hotkey, input::TypingMethod, platform::get_home_dir};
 use once_cell::sync::Lazy;
 
 pub static HOTKEY_CONFIG: Lazy<Hotkey> = Lazy::new(|| Hotkey::from("super+ctrl+space"));
+
+struct ConfigStore {
+    data: HashMap<String, String>,
+}
+
+impl ConfigStore {
+    fn get_config_path() -> PathBuf {
+        get_home_dir()
+            .expect("Cannot read home directory!")
+            .join(".goxkey")
+    }
+
+    fn load_config_data() -> Result<HashMap<String, String>> {
+        let mut data = HashMap::new();
+        let config_path = ConfigStore::get_config_path();
+        let mut file = File::open(config_path.as_path())?;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf);
+        buf.lines().for_each(|line| {
+            if let Some((key, value)) = line.split_once('=') {
+                data.insert(key.trim().to_owned(), value.trim().to_owned());
+            }
+        });
+        Ok(data)
+    }
+
+    fn write_config_data(data: &HashMap<String, String>) -> Result<()> {
+        let config_path = ConfigStore::get_config_path();
+        let mut file = File::create(config_path.as_path())?;
+        let mut content = String::new();
+        for (key, value) in data {
+            content.push_str(&format!("{} = {}\n", key, value));
+        }
+        file.write_all(content.as_bytes())
+    }
+
+    pub fn new() -> Self {
+        Self {
+            data: ConfigStore::load_config_data().expect("Cannot read config file!"),
+        }
+    }
+
+    pub fn read(&self, key: &str) -> String {
+        return self.data.get(key).unwrap_or(&String::new()).to_string();
+    }
+
+    pub fn write(&mut self, key: &str, value: &str) {
+        self.data.insert(key.to_string(), value.to_string());
+        ConfigStore::write_config_data(&self.data).expect("Cannot write to config file!");
+    }
+}
+
+const HOTKEY_CONFIG_KEY: &str = "hotkey";
+const TYPING_METHOD_CONFIG_KEY: &str = "method";
+
+pub struct ConfigManager {
+    hotkey: Hotkey,
+    typing_method: TypingMethod,
+    config_store: ConfigStore,
+}
+
+impl ConfigManager {
+    pub fn new() -> Self {
+        let store = ConfigStore::new();
+        let hotkey = Hotkey::from(&store.read(HOTKEY_CONFIG_KEY));
+        let method = match store.read(TYPING_METHOD_CONFIG_KEY).to_lowercase().as_str() {
+            "vni" => TypingMethod::VNI,
+            _ => TypingMethod::Telex,
+        };
+        Self {
+            hotkey,
+            typing_method: method,
+            config_store: store,
+        }
+    }
+
+    pub fn get_hotkey(&self) -> &Hotkey {
+        return &self.hotkey;
+    }
+
+    pub fn get_typing_method(&self) -> &TypingMethod {
+        return &self.typing_method;
+    }
+
+    pub fn set_hotkey(&mut self, key_sequence: &str) {
+        self.hotkey = Hotkey::from(key_sequence);
+        self.config_store.write(HOTKEY_CONFIG_KEY, key_sequence);
+    }
+
+    pub fn set_typing_method(&mut self, method: TypingMethod) {
+        self.typing_method = method;
+        self.config_store
+            .write(TYPING_METHOD_CONFIG_KEY, &method.to_string());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,4 @@
+use crate::hotkey::Hotkey;
+use once_cell::sync::Lazy;
+
+pub static HOTKEY_CONFIG: Lazy<Hotkey> = Lazy::new(|| Hotkey::from("super+ctrl+space"));

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -1,0 +1,123 @@
+use std::fmt::Display;
+
+use crate::platform::{
+    KeyModifier, KEY_DELETE, KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_TAB, SYMBOL_ALT, SYMBOL_CTRL,
+    SYMBOL_SHIFT, SYMBOL_SUPER,
+};
+
+pub struct Hotkey {
+    modifiers: KeyModifier,
+    keycode: char,
+}
+
+impl Hotkey {
+    pub fn from(input: &str) -> Self {
+        let mut modifiers = KeyModifier::new();
+        let mut keycode: char = '\0';
+        input
+            .split('+')
+            .for_each(|token| match token.trim().to_uppercase().as_str() {
+                "SHIFT" => modifiers.add_shift(),
+                "ALT" => modifiers.add_alt(),
+                "SUPER" => modifiers.add_super(),
+                "CTRL" => modifiers.add_control(),
+                "ENTER" => keycode = KEY_ENTER,
+                "SPACE" => keycode = KEY_SPACE,
+                "TAB" => keycode = KEY_TAB,
+                "DELETE" => keycode = KEY_DELETE,
+                "ESC" => keycode = KEY_ESCAPE,
+                c => {
+                    keycode = c.chars().last().unwrap();
+                }
+            });
+        Self { modifiers, keycode }
+    }
+
+    pub fn is_match(&self, modifiers: KeyModifier, keycode: &char) -> bool {
+        return self.modifiers == modifiers && self.keycode.eq_ignore_ascii_case(keycode);
+    }
+}
+
+impl Display for Hotkey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut keys = String::new();
+        if self.modifiers.is_control() {
+            keys.push_str(SYMBOL_CTRL);
+            keys.push_str(" ");
+        }
+        if self.modifiers.is_shift() {
+            keys.push_str(SYMBOL_SHIFT);
+            keys.push_str(" ");
+        }
+        if self.modifiers.is_alt() {
+            keys.push_str(SYMBOL_ALT);
+            keys.push_str(" ");
+        }
+        if self.modifiers.is_super() {
+            keys.push_str(SYMBOL_SUPER);
+            keys.push_str(" ");
+        }
+        match self.keycode {
+            KEY_ENTER => keys.push_str("Enter"),
+            KEY_SPACE => keys.push_str("Space"),
+            KEY_TAB => keys.push_str("Tab"),
+            KEY_DELETE => keys.push_str("Del"),
+            KEY_ESCAPE => keys.push_str("Esc"),
+            c => keys.push_str(format!("{}", c.to_uppercase()).as_str()),
+        }
+        write!(f, "{}", keys)
+    }
+}
+
+#[test]
+fn test_parse() {
+    let hotkey = Hotkey::from("super+shift+z");
+    let mut actual_modifier = KeyModifier::new();
+    actual_modifier.add_shift();
+    actual_modifier.add_super();
+    assert_eq!(hotkey.modifiers, actual_modifier);
+    assert_eq!(hotkey.keycode, 'Z');
+    assert_eq!(hotkey.is_match(actual_modifier, &'z'), true);
+}
+
+#[test]
+fn test_parse_long_input() {
+    let hotkey = Hotkey::from("super+shift+ctrl+alt+w");
+    let mut actual_modifier = KeyModifier::new();
+    actual_modifier.add_shift();
+    actual_modifier.add_super();
+    actual_modifier.add_control();
+    actual_modifier.add_alt();
+    assert_eq!(hotkey.modifiers, actual_modifier);
+    assert_eq!(hotkey.keycode, 'W');
+    assert_eq!(hotkey.is_match(actual_modifier, &'W'), true);
+}
+
+#[test]
+fn test_parse_with_named_keycode() {
+    let hotkey = Hotkey::from("super+ctrl+space");
+    let mut actual_modifier = KeyModifier::new();
+    actual_modifier.add_super();
+    actual_modifier.add_control();
+    assert_eq!(hotkey.modifiers, actual_modifier);
+    assert_eq!(hotkey.keycode, KEY_SPACE);
+    assert_eq!(hotkey.is_match(actual_modifier, &KEY_SPACE), true);
+}
+
+#[test]
+fn test_display() {
+    assert_eq!(
+        format!("{}", Hotkey::from("super+ctrl+space")),
+        format!("{} {} Space", SYMBOL_CTRL, SYMBOL_SUPER)
+    );
+
+    assert_eq!(
+        format!("{}", Hotkey::from("super+alt+z")),
+        format!("{} {} Z", SYMBOL_ALT, SYMBOL_SUPER)
+    );
+
+    assert_eq!(
+        format!("{}", Hotkey::from("ctrl+shift+o")),
+        format!("{} {} O", SYMBOL_CTRL, SYMBOL_SHIFT)
+    );
+}

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -11,7 +11,7 @@ pub struct Hotkey {
 }
 
 impl Hotkey {
-    pub fn from(input: &str) -> Self {
+    pub fn from_str(input: &str) -> Self {
         let mut modifiers = KeyModifier::new();
         let mut keycode: char = '\0';
         input
@@ -33,8 +33,16 @@ impl Hotkey {
         Self { modifiers, keycode }
     }
 
+    pub fn from(modifiers: KeyModifier, keycode: char) -> Self {
+        Self { modifiers, keycode }
+    }
+
     pub fn is_match(&self, modifiers: KeyModifier, keycode: &char) -> bool {
         return self.modifiers == modifiers && self.keycode.eq_ignore_ascii_case(keycode);
+    }
+
+    pub fn inner(&self) -> (KeyModifier, char) {
+        (self.modifiers, self.keycode)
     }
 }
 
@@ -65,7 +73,7 @@ impl Display for Hotkey {
 
 #[test]
 fn test_parse() {
-    let hotkey = Hotkey::from("super+shift+z");
+    let hotkey = Hotkey::from_str("super+shift+z");
     let mut actual_modifier = KeyModifier::new();
     actual_modifier.add_shift();
     actual_modifier.add_super();
@@ -76,7 +84,7 @@ fn test_parse() {
 
 #[test]
 fn test_parse_long_input() {
-    let hotkey = Hotkey::from("super+shift+ctrl+alt+w");
+    let hotkey = Hotkey::from_str("super+shift+ctrl+alt+w");
     let mut actual_modifier = KeyModifier::new();
     actual_modifier.add_shift();
     actual_modifier.add_super();
@@ -89,7 +97,7 @@ fn test_parse_long_input() {
 
 #[test]
 fn test_parse_with_named_keycode() {
-    let hotkey = Hotkey::from("super+ctrl+space");
+    let hotkey = Hotkey::from_str("super+ctrl+space");
     let mut actual_modifier = KeyModifier::new();
     actual_modifier.add_super();
     actual_modifier.add_control();
@@ -101,17 +109,17 @@ fn test_parse_with_named_keycode() {
 #[test]
 fn test_display() {
     assert_eq!(
-        format!("{}", Hotkey::from("super+ctrl+space")),
+        format!("{}", Hotkey::from_str("super+ctrl+space")),
         format!("{} {} Space", SYMBOL_CTRL, SYMBOL_SUPER)
     );
 
     assert_eq!(
-        format!("{}", Hotkey::from("super+alt+z")),
+        format!("{}", Hotkey::from_str("super+alt+z")),
         format!("{} {} Z", SYMBOL_ALT, SYMBOL_SUPER)
     );
 
     assert_eq!(
-        format!("{}", Hotkey::from("ctrl+shift+o")),
+        format!("{}", Hotkey::from_str("ctrl+shift+o")),
         format!("{} {} O", SYMBOL_CTRL, SYMBOL_SHIFT)
     );
 }

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -41,16 +41,16 @@ impl Hotkey {
 impl Display for Hotkey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.modifiers.is_control() {
-            _ = write!(f, "{} ", SYMBOL_CTRL);
+            write!(f, "{} ", SYMBOL_CTRL)?;
         }
         if self.modifiers.is_shift() {
-            _ = write!(f, "{} ", SYMBOL_SHIFT);
+            write!(f, "{} ", SYMBOL_SHIFT)?;
         }
         if self.modifiers.is_alt() {
-            _ = write!(f, "{} ", SYMBOL_ALT);
+            write!(f, "{} ", SYMBOL_ALT)?;
         }
         if self.modifiers.is_super() {
-            _ = write!(f, "{} ", SYMBOL_SUPER);
+            write!(f, "{} ", SYMBOL_SUPER)?;
         }
         write!(
             f,

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{ascii::AsciiExt, fmt::Display};
 
 use crate::platform::{
     KeyModifier, KEY_DELETE, KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_TAB, SYMBOL_ALT, SYMBOL_CTRL,
@@ -52,18 +52,14 @@ impl Display for Hotkey {
         if self.modifiers.is_super() {
             write!(f, "{} ", SYMBOL_SUPER)?;
         }
-        write!(
-            f,
-            "{}",
-            match self.keycode {
-                KEY_ENTER => "Enter".to_owned(),
-                KEY_SPACE => "Space".to_owned(),
-                KEY_TAB => "Tab".to_owned(),
-                KEY_DELETE => "Del".to_owned(),
-                KEY_ESCAPE => "Esc".to_owned(),
-                c => format!("{}", c.to_uppercase()),
-            }
-        )
+        match self.keycode {
+            KEY_ENTER => write!(f, "Enter"),
+            KEY_SPACE => write!(f, "Space"),
+            KEY_TAB => write!(f, "Tab"),
+            KEY_DELETE => write!(f, "Del"),
+            KEY_ESCAPE => write!(f, "Esc"),
+            c => write!(f, "{}", c.to_ascii_uppercase()),
+        }
     }
 }
 

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -40,32 +40,30 @@ impl Hotkey {
 
 impl Display for Hotkey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut keys = String::new();
         if self.modifiers.is_control() {
-            keys.push_str(SYMBOL_CTRL);
-            keys.push_str(" ");
+            _ = write!(f, "{} ", SYMBOL_CTRL);
         }
         if self.modifiers.is_shift() {
-            keys.push_str(SYMBOL_SHIFT);
-            keys.push_str(" ");
+            _ = write!(f, "{} ", SYMBOL_SHIFT);
         }
         if self.modifiers.is_alt() {
-            keys.push_str(SYMBOL_ALT);
-            keys.push_str(" ");
+            _ = write!(f, "{} ", SYMBOL_ALT);
         }
         if self.modifiers.is_super() {
-            keys.push_str(SYMBOL_SUPER);
-            keys.push_str(" ");
+            _ = write!(f, "{} ", SYMBOL_SUPER);
         }
-        match self.keycode {
-            KEY_ENTER => keys.push_str("Enter"),
-            KEY_SPACE => keys.push_str("Space"),
-            KEY_TAB => keys.push_str("Tab"),
-            KEY_DELETE => keys.push_str("Del"),
-            KEY_ESCAPE => keys.push_str("Esc"),
-            c => keys.push_str(format!("{}", c.to_uppercase()).as_str()),
-        }
-        write!(f, "{}", keys)
+        write!(
+            f,
+            "{}",
+            match self.keycode {
+                KEY_ENTER => "Enter".to_owned(),
+                KEY_SPACE => "Space".to_owned(),
+                KEY_TAB => "Tab".to_owned(),
+                KEY_DELETE => "Del".to_owned(),
+                KEY_ESCAPE => "Esc".to_owned(),
+                c => format!("{}", c.to_uppercase()),
+            }
+        )
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use druid::Data;
 use log::debug;
 use once_cell::sync::Lazy;
@@ -27,6 +29,19 @@ pub static mut INPUT_STATE: Lazy<InputState> = Lazy::new(|| InputState::new());
 pub enum TypingMethod {
     VNI,
     Telex,
+}
+
+impl Display for TypingMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::VNI => "vni",
+                Self::Telex => "telex",
+            }
+        )
+    }
 }
 
 pub struct InputState {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,8 +1,15 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
-use druid::Data;
+use druid::{Data, Target};
 use log::debug;
 use once_cell::sync::Lazy;
+
+use crate::{
+    config::{CONFIG_MANAGER, HOTKEY_CONFIG_KEY, TYPING_METHOD_CONFIG_KEY},
+    hotkey::Hotkey,
+    ui::UPDATE_UI,
+    UI_EVENT_SINK,
+};
 
 // According to Google search, the longest possible Vietnamese word
 // is "nghiêng", which is 7 letters long. Add a little buffer for
@@ -31,6 +38,17 @@ pub enum TypingMethod {
     Telex,
 }
 
+impl FromStr for TypingMethod {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_ascii_lowercase().as_str() {
+            "vni" => TypingMethod::VNI,
+            _ => TypingMethod::Telex,
+        })
+    }
+}
+
 impl Display for TypingMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -48,16 +66,19 @@ pub struct InputState {
     buffer: String,
     display_buffer: String,
     method: TypingMethod,
+    hotkey: Hotkey,
     enabled: bool,
     should_track: bool,
 }
 
 impl InputState {
     pub fn new() -> Self {
+        let config = CONFIG_MANAGER.lock().unwrap();
         Self {
             buffer: String::new(),
             display_buffer: String::new(),
-            method: TypingMethod::Telex,
+            method: TypingMethod::from_str(&config.read(TYPING_METHOD_CONFIG_KEY)).unwrap(),
+            hotkey: Hotkey::from_str(&config.read(HOTKEY_CONFIG_KEY)),
             enabled: true,
             should_track: true,
         }
@@ -95,10 +116,32 @@ impl InputState {
     pub fn set_method(&mut self, method: TypingMethod) {
         self.method = method;
         self.new_word();
+        CONFIG_MANAGER
+            .lock()
+            .unwrap()
+            .write(TYPING_METHOD_CONFIG_KEY, &method.to_string());
+        if let Some(event_sink) = UI_EVENT_SINK.get() {
+            _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
+        }
     }
 
     pub fn get_method(&self) -> TypingMethod {
         self.method
+    }
+
+    pub fn set_hotkey(&mut self, key_sequence: &str) {
+        self.hotkey = Hotkey::from_str(key_sequence);
+        CONFIG_MANAGER
+            .lock()
+            .unwrap()
+            .write(HOTKEY_CONFIG_KEY, key_sequence);
+        if let Some(event_sink) = UI_EVENT_SINK.get() {
+            _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
+        }
+    }
+
+    pub fn get_hotkey(&self) -> &Hotkey {
+        return &self.hotkey;
     }
 
     pub fn should_transform_keys(&self, c: &char) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
+mod config;
+mod hotkey;
 mod input;
 mod platform;
 mod ui;
 
+use config::HOTKEY_CONFIG;
 use druid::{AppLauncher, ExtEventSink, Target, WindowDesc};
 use input::INPUT_STATE;
 use log::debug;
-use once_cell::sync::OnceCell;
+use once_cell::sync::{Lazy, OnceCell};
 use platform::{
     run_event_listener, send_backspace, send_string, Handle, KeyModifier, KEY_DELETE, KEY_ENTER,
     KEY_ESCAPE, KEY_SPACE, KEY_TAB,
@@ -37,7 +40,7 @@ fn event_handler(handle: Handle, keycode: Option<char>, modifiers: KeyModifier) 
         match keycode {
             Some(keycode) => {
                 // Toggle Vietnamese input mod with Ctrl + Cmd + Space key
-                if modifiers.is_control() && modifiers.is_super() && keycode == KEY_SPACE {
+                if HOTKEY_CONFIG.is_match(modifiers, &keycode) {
                     INPUT_STATE.toggle_vietnamese();
                     if let Some(event_sink) = UI_EVENT_SINK.get() {
                         _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use config::HOTKEY_CONFIG;
 use druid::{AppLauncher, ExtEventSink, Target, WindowDesc};
 use input::INPUT_STATE;
 use log::debug;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use platform::{
     run_event_listener, send_backspace, send_string, Handle, KeyModifier, KEY_DELETE, KEY_ENTER,
     KEY_ESCAPE, KEY_SPACE, KEY_TAB,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod input;
 mod platform;
 mod ui;
 
-use config::HOTKEY_CONFIG;
 use druid::{AppLauncher, ExtEventSink, Target, WindowDesc};
 use input::INPUT_STATE;
 use log::debug;
@@ -40,7 +39,7 @@ fn event_handler(handle: Handle, keycode: Option<char>, modifiers: KeyModifier) 
         match keycode {
             Some(keycode) => {
                 // Toggle Vietnamese input mod with Ctrl + Cmd + Space key
-                if HOTKEY_CONFIG.is_match(modifiers, &keycode) {
+                if INPUT_STATE.get_hotkey().is_match(modifiers, &keycode) {
                     INPUT_STATE.toggle_vietnamese();
                     if let Some(event_sink) = UI_EVENT_SINK.get() {
                         _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
@@ -102,7 +101,7 @@ fn main() {
 
     let win = WindowDesc::new(ui::main_ui_builder)
         .title("gõkey")
-        .window_size((320.0, 200.0))
+        .window_size((320.0, 234.0))
         .resizable(false);
     let app = AppLauncher::with_window(win);
     let event_sink = app.get_external_handle();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -7,6 +7,10 @@ pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "❖";
 pub const SYMBOL_ALT: &str = "⌥";
 
+pub fn get_home_dir() -> Option<PathBuf> {
+    env::var("HOME").ok().map(PathBuf::from)
+}
+
 pub fn send_backspace(count: usize) -> Result<(), ()> {
     todo!()
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -2,6 +2,11 @@
 
 use super::CallbackFn;
 
+pub const SYMBOL_SHIFT: &str = "⇧";
+pub const SYMBOL_CTRL: &str = "⌃";
+pub const SYMBOL_SUPER: &str = "❖";
+pub const SYMBOL_ALT: &str = "⌥";
+
 pub fn send_backspace(count: usize) -> Result<(), ()> {
     todo!()
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+use std::{env, os, path::PathBuf, ptr};
 
 use super::{CallbackFn, KeyModifier, KEY_DELETE, KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_TAB};
 use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
@@ -16,6 +16,10 @@ pub const SYMBOL_SHIFT: &str = "⇧";
 pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "⌘";
 pub const SYMBOL_ALT: &str = "⌥";
+
+pub fn get_home_dir() -> Option<PathBuf> {
+    env::var("HOME").ok().map(PathBuf::from)
+}
 
 // Modified from http://ritter.ist.psu.edu/projects/RUI/macosx/rui.c
 fn get_char(keycode: CGKeyCode) -> Option<char> {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -12,6 +12,11 @@ use core_graphics::{
 
 pub type Handle = CGEventTapProxy;
 
+pub const SYMBOL_SHIFT: &str = "⇧";
+pub const SYMBOL_CTRL: &str = "⌃";
+pub const SYMBOL_SUPER: &str = "⌘";
+pub const SYMBOL_ALT: &str = "⌥";
+
 // Modified from http://ritter.ist.psu.edu/projects/RUI/macosx/rui.c
 fn get_char(keycode: CGKeyCode) -> Option<char> {
     match keycode {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,7 +4,10 @@
 mod os;
 
 use bitflags::bitflags;
-pub use os::{run_event_listener, send_backspace, send_string, Handle};
+pub use os::{
+    run_event_listener, send_backspace, send_string, Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT,
+    SYMBOL_SUPER,
+};
 
 pub const KEY_ENTER: char = '\x13';
 pub const KEY_SPACE: char = '\x32';

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -3,6 +3,8 @@
 #[cfg_attr(target_os = "window", path = "window.rs")]
 mod os;
 
+use std::fmt::Display;
+
 use bitflags::bitflags;
 pub use os::{
     get_home_dir, run_event_listener, send_backspace, send_string, Handle, SYMBOL_ALT, SYMBOL_CTRL,
@@ -10,7 +12,7 @@ pub use os::{
 };
 
 pub const KEY_ENTER: char = '\x13';
-pub const KEY_SPACE: char = '\x32';
+pub const KEY_SPACE: char = '\u{0020}';
 pub const KEY_TAB: char = '\x09';
 pub const KEY_DELETE: char = '\x08';
 pub const KEY_ESCAPE: char = '\x26';
@@ -25,9 +27,34 @@ bitflags! {
     }
 }
 
+impl Display for KeyModifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_super() {
+            write!(f, "super+")?;
+        }
+        if self.is_control() {
+            write!(f, "ctrl+")?;
+        }
+        if self.is_alt() {
+            write!(f, "alt+")?;
+        }
+        if self.is_shift() {
+            write!(f, "shift+")?;
+        }
+        write!(f, "")
+    }
+}
+
 impl KeyModifier {
     pub fn new() -> Self {
         Self { bits: 0 }
+    }
+
+    pub fn apply(&mut self, is_super: bool, is_ctrl: bool, is_alt: bool, is_shift: bool) {
+        self.set(Self::MODIFIER_SUPER, is_super);
+        self.set(Self::MODIFIER_CONTROL, is_ctrl);
+        self.set(Self::MODIFIER_ALT, is_alt);
+        self.set(Self::MODIFIER_SHIFT, is_shift);
     }
 
     pub fn add_shift(&mut self) {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -5,8 +5,8 @@ mod os;
 
 use bitflags::bitflags;
 pub use os::{
-    run_event_listener, send_backspace, send_string, Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT,
-    SYMBOL_SUPER,
+    get_home_dir, run_event_listener, send_backspace, send_string, Handle, SYMBOL_ALT, SYMBOL_CTRL,
+    SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 pub const KEY_ENTER: char = '\x13';

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2,6 +2,11 @@
 
 use super::CallbackFn;
 
+pub const SYMBOL_SHIFT: &str = "⇧";
+pub const SYMBOL_CTRL: &str = "⌃";
+pub const SYMBOL_SUPER: &str = "⊞";
+pub const SYMBOL_ALT: &str = "⌥";
+
 pub fn send_backspace(count: usize) -> Result<(), ()> {
     todo!()
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -7,6 +7,15 @@ pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "⊞";
 pub const SYMBOL_ALT: &str = "⌥";
 
+pub fn get_home_dir() -> Option<PathBuf> {
+    env::var("USERPROFILE").ok().map(PathBuf::from)
+        .or_else(|| env::var("HOMEDRIVE").ok().and_then(|home_drive| {
+            env::var("HOMEPATH").ok().map(|home_path| {
+                PathBuf::from(format!("{}{}", home_drive, home_path))
+            })
+        }))
+}
+
 pub fn send_backspace(count: usize) -> Result<(), ()> {
     todo!()
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,19 +1,72 @@
 use crate::{
-    config::HOTKEY_CONFIG,
     input::{TypingMethod, INPUT_STATE},
+    platform::{KeyModifier, KEY_SPACE, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER},
 };
 use druid::{
+    text::{
+        format::{Formatter, Validation},
+        TextInput,
+    },
     theme::{BACKGROUND_DARK, BORDER_DARK, PLACEHOLDER_COLOR},
-    widget::{Button, Container, Controller, Flex, Label, RadioGroup, Switch},
-    Data, Env, Event, EventCtx, Lens, Selector, Widget, WidgetExt,
+    widget::{Button, Checkbox, Container, Controller, Flex, Label, RadioGroup, Switch, TextBox},
+    Data, Env, Event, EventCtx, KeyModifiers, Lens, Selector, Widget, WidgetExt,
 };
 
 pub const UPDATE_UI: Selector = Selector::new("gox-ui.update-ui");
 
-#[derive(Clone, Data, Lens)]
+// TODO:
+// 2. Implement update for Controller to submit change to INPUT_STATE
+
+pub fn format_letter_key(c: char) -> String {
+    if c.is_ascii_whitespace() {
+        String::from("Space")
+    } else {
+        c.to_ascii_uppercase().to_string()
+    }
+}
+
+pub fn letter_key_to_char(input: &str) -> char {
+    match input {
+        "Space" => ' ',
+        s => s.chars().last().unwrap(),
+    }
+}
+
+struct LetterKeyController;
+impl<W: Widget<UIDataAdapter>> Controller<UIDataAdapter, W> for LetterKeyController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut UIDataAdapter,
+        env: &Env,
+    ) {
+        if let &Event::KeyUp(_) = event {
+            match data.letter_key.as_str() {
+                "Space" => {}
+                s => {
+                    if let Some(last_char) = s.chars().last() {
+                        data.letter_key = format_letter_key(last_char);
+                    }
+                }
+            }
+        }
+        child.event(ctx, event, data, env)
+    }
+}
+
+#[derive(Clone, Data, Lens, PartialEq, Eq)]
 pub struct UIDataAdapter {
     is_enabled: bool,
     typing_method: TypingMethod,
+    hotkey_display: String,
+    // Hotkey config
+    super_key: bool,
+    ctrl_key: bool,
+    alt_key: bool,
+    shift_key: bool,
+    letter_key: String,
 }
 
 impl UIDataAdapter {
@@ -21,6 +74,13 @@ impl UIDataAdapter {
         let mut ret = Self {
             is_enabled: true,
             typing_method: TypingMethod::Telex,
+            hotkey_display: String::new(),
+            // TODO: These values should be read from hotkey object
+            super_key: true,
+            ctrl_key: true,
+            alt_key: false,
+            shift_key: false,
+            letter_key: String::from("Space"),
         };
         ret.update();
         ret
@@ -30,6 +90,14 @@ impl UIDataAdapter {
         unsafe {
             self.is_enabled = INPUT_STATE.is_enabled();
             self.typing_method = INPUT_STATE.get_method();
+            self.hotkey_display = INPUT_STATE.get_hotkey().to_string();
+
+            let (modifiers, keycode) = INPUT_STATE.get_hotkey().inner();
+            self.super_key = modifiers.is_super();
+            self.ctrl_key = modifiers.is_control();
+            self.alt_key = modifiers.is_alt();
+            self.shift_key = modifiers.is_shift();
+            self.letter_key = format_letter_key(keycode);
         }
     }
 
@@ -62,6 +130,38 @@ impl<W: Widget<UIDataAdapter>> Controller<UIDataAdapter, W> for UIController {
             _ => {}
         }
         child.event(ctx, event, data, env)
+    }
+
+    fn update(
+        &mut self,
+        child: &mut W,
+        ctx: &mut druid::UpdateCtx,
+        old_data: &UIDataAdapter,
+        data: &UIDataAdapter,
+        env: &Env,
+    ) {
+        unsafe {
+            if old_data.typing_method != data.typing_method {
+                INPUT_STATE.set_method(data.typing_method);
+            }
+
+            if !data.letter_key.is_empty() {
+                let mut new_mod = KeyModifier::new();
+                new_mod.apply(data.super_key, data.ctrl_key, data.alt_key, data.shift_key);
+                let key_code = letter_key_to_char(&data.letter_key);
+                if !INPUT_STATE.get_hotkey().is_match(new_mod, &key_code) {
+                    INPUT_STATE.set_hotkey(&format!(
+                        "{}{}",
+                        new_mod,
+                        match key_code {
+                            ' ' => String::from("space"),
+                            c => c.to_string(),
+                        }
+                    ));
+                }
+            }
+        }
+        child.update(ctx, old_data, data, env);
     }
 }
 
@@ -108,11 +208,30 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                         Flex::row()
                             .with_child(Label::new("Bật tắt gõ tiếng Việt"))
                             .with_child(
-                                Label::new(HOTKEY_CONFIG.to_string())
-                                    .border(PLACEHOLDER_COLOR, 1.0)
-                                    .rounded(4.0),
+                                Label::dynamic(|data: &UIDataAdapter, _| {
+                                    data.hotkey_display.to_owned()
+                                })
+                                .border(PLACEHOLDER_COLOR, 1.0)
+                                .rounded(4.0),
                             )
                             .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                            .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
+                            .must_fill_main_axis(true)
+                            .expand_width()
+                            .padding(8.0),
+                    )
+                    .with_child(
+                        Flex::row()
+                            .with_child(Checkbox::new(SYMBOL_SUPER).lens(UIDataAdapter::super_key))
+                            .with_child(Checkbox::new(SYMBOL_CTRL).lens(UIDataAdapter::ctrl_key))
+                            .with_child(Checkbox::new(SYMBOL_ALT).lens(UIDataAdapter::alt_key))
+                            .with_child(Checkbox::new(SYMBOL_SHIFT).lens(UIDataAdapter::shift_key))
+                            .with_child(
+                                TextBox::new()
+                                    .lens(UIDataAdapter::letter_key)
+                                    .controller(LetterKeyController),
+                            )
+                            .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
                             .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
                             .must_fill_main_axis(true)
                             .expand_width()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,7 @@
-use crate::input::{TypingMethod, INPUT_STATE};
+use crate::{
+    config::HOTKEY_CONFIG,
+    input::{TypingMethod, INPUT_STATE},
+};
 use druid::{
     theme::{BACKGROUND_DARK, BORDER_DARK, PLACEHOLDER_COLOR},
     widget::{Button, Container, Controller, Flex, Label, RadioGroup, Switch},
@@ -105,7 +108,7 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                         Flex::row()
                             .with_child(Label::new("Bật tắt gõ tiếng Việt"))
                             .with_child(
-                                Label::new("⌃ ⌘ Space")
+                                Label::new(HOTKEY_CONFIG.to_string())
                                     .border(PLACEHOLDER_COLOR, 1.0)
                                     .rounded(4.0),
                             )


### PR DESCRIPTION
This PR added some preliminary works for #5 

1. Implement a hotkey matcher: Now we can create a hotkey definition from a key sequence string like `"super + ctrl + space"`, `"shift + Z"`, and use this hotkey to toggle the Vietnamese input mode
2. Render the configured hotkey to the UI: translate the configured hotkey into a proper symbols, like <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>Space</kbd>. This implementation also handle the different symbol between the platforms, for example <kbd>❖</kbd> for super key on Linux, and <kbd>⌘</kbd> on macOS.

![hotkey-screenshot](https://user-images.githubusercontent.com/613943/217435830-579185a2-1f51-43f1-9e29-96121904fa77.png)

Fixes #5 #6

