### PR TITLE
Added an extra backspace to compensate text selection deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,25 @@
 version = 3
 
 [[package]]
+name = "accessibility"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ad4ccded014d35a7b1a262bb1ebbc076593189748f0ff6d2ba19f8ddfecef0"
+dependencies = [
+ "accessibility-sys",
+ "core-foundation 0.9.3",
+]
+
+[[package]]
+name = "accessibility-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf09354dda54177da27bcb8b9b83d8cab947db1dc1538a310a5e9da1c57fd4c2"
+dependencies = [
+ "core-foundation-sys 0.8.3",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +746,8 @@ dependencies = [
 name = "goxkey"
 version = "0.1.0"
 dependencies = [
+ "accessibility",
+ "accessibility-sys",
  "bitflags",
  "cocoa 0.24.1",
  "core-foundation 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ cocoa = "0.24"
 objc = "0.2"
 objc-foundation = "0.1"
 objc_id = "0.1"
+accessibility = "0.1.6"
+accessibility-sys = "0.1.3"
 
 [package.metadata.bundle]
 copyright = "Copyright (c) Huy Tran 2023. All rights reserved."

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@ use rdev::{Keyboard, KeyboardState};
 use crate::{
     config::{CONFIG_MANAGER, HOTKEY_CONFIG_KEY, TYPING_METHOD_CONFIG_KEY},
     hotkey::Hotkey,
+    platform::is_in_text_selection,
     ui::UPDATE_UI,
     UI_EVENT_SINK,
 };
@@ -250,10 +251,20 @@ impl InputState {
 
     pub fn get_backspace_count(&self, is_delete: bool) -> usize {
         let dp_len = self.display_buffer.chars().count();
-        if is_delete && dp_len >= 1 {
+        let backspace_count = if is_delete && dp_len >= 1 {
             dp_len
         } else {
             dp_len - 1
+        };
+
+        // Add an extra backspace to compensate the initial text selection deletion.
+        // This is useful in applications like chrome, where the URL bar uses text selection
+        // for autocompletion, causing the first backspace to delete the selection instead of
+        // the character behind the cursor.
+        if is_in_text_selection() {
+            backspace_count + 1
+        } else {
+            backspace_count
         }
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -22,3 +22,7 @@ pub fn send_string(string: &str) -> Result<(), ()> {
 pub fn run_event_listener(callback: &CallbackFn) {
     todo!()
 }
+
+pub fn is_in_text_selection() -> bool {
+    todo!()
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -11,7 +11,12 @@ use core_graphics::{
 pub use macos_ext::SystemTray;
 
 use crate::input::KEYBOARD_LAYOUT_CHARACTER_MAP;
-use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
+use accessibility::{AXAttribute, AXUIElement};
+use accessibility_sys::{kAXFocusedUIElementAttribute, kAXSelectedTextAttribute};
+use core_foundation::{
+    runloop::{kCFRunLoopCommonModes, CFRunLoop},
+    string::CFString,
+};
 
 pub use self::macos_ext::Handle;
 use self::macos_ext::{
@@ -83,6 +88,23 @@ fn get_char(keycode: CGKeyCode) -> Option<char> {
         };
     }
     None
+}
+
+pub fn is_in_text_selection() -> bool {
+    let system_element = AXUIElement::system_wide();
+    let Some(selected_element) = system_element.attribute(&AXAttribute::new(&CFString::from_static_string(kAXFocusedUIElementAttribute)))
+        .map(|elemenet| elemenet.downcast_into::<AXUIElement>())
+        .ok()
+        .flatten() else {
+            return false;
+        };
+    let Some(selected_text) = selected_element.attribute(&AXAttribute::new(&CFString::from_static_string(kAXSelectedTextAttribute)))
+        .map(|text| text.downcast_into::<CFString>())
+        .ok()
+        .flatten() else {
+            return false;
+        };
+    !selected_text.to_string().is_empty()
 }
 
 pub fn send_backspace(handle: Handle, count: usize) -> Result<(), ()> {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,8 +7,8 @@ use std::fmt::Display;
 
 use bitflags::bitflags;
 pub use os::{
-    get_home_dir, run_event_listener, send_backspace, send_string, Handle, SYMBOL_ALT, SYMBOL_CTRL,
-    SYMBOL_SHIFT, SYMBOL_SUPER,
+    get_home_dir, is_in_text_selection, run_event_listener, send_backspace, send_string, Handle,
+    SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 #[cfg(target_os = "macos")]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -27,3 +27,7 @@ pub fn send_string(string: &str) -> Result<(), ()> {
 pub fn run_event_listener(callback: &CallbackFn) {
     todo!()
 }
+
+pub fn is_in_text_selection() -> bool {
+    todo!()
+}


### PR DESCRIPTION
Fixed https://github.com/huytd/goxkey/issues/16.

Rảnh rỗi ngồi fix thử ai ngờ fix được luôn há há.

Lỗi này là do thanh tìm kiếm dùng text selection để bôi xanh kết quả đầu tiên trong list autocomplete:
![image](https://user-images.githubusercontent.com/12984316/221401971-01954916-00dd-478d-bd86-2e304bf4ef1d.png)

Nên khi goxkey gửi mớ backspace thì cái backspace đầu tiên sẽ được tính là text selection deletion chứ không tính là delete ký tự sau vị trí con trỏ. Ví dụ `gox` sẽ send 3 backspace nhưng do cái đầu tiên không tính nên chỉ còn có 2 backspace là có hiệu lực => chỉ delete tới `g` sau đó insert thêm `gox` => `ggõ` 😂 

Cách giải quyết hiện tại là tặng thêm một ký tự backspace để bù trừ cho trường hợp đang có text selection. MacOS có vẻ không có vấn đề nhưng Windows với Linux chắc sẽ khoai. Mà tới lúc đó tính cũng được 😂 