### PR TITLE
fix: Fix hotkey does not work when Caps Lock is on

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -33,7 +33,10 @@ impl Hotkey {
         Self { modifiers, keycode }
     }
 
-    pub fn is_match(&self, modifiers: KeyModifier, keycode: &char) -> bool {
+    pub fn is_match(&self, mut modifiers: KeyModifier, keycode: &char) -> bool {
+        // Caps Lock should not interfere with any hotkey
+        modifiers.remove(KeyModifier::MODIFIER_CAPSLOCK);
+
         self.modifiers == modifiers && self.keycode.eq_ignore_ascii_case(keycode)
     }
 
@@ -100,6 +103,18 @@ fn test_parse_with_named_keycode() {
     assert_eq!(hotkey.modifiers, actual_modifier);
     assert_eq!(hotkey.keycode, KEY_SPACE);
     assert!(hotkey.is_match(actual_modifier, &KEY_SPACE));
+}
+
+#[test]
+fn test_can_match_with_or_without_capslock() {
+    let hotkey = Hotkey::from_str("super+ctrl+space");
+    let mut actual_modifier = KeyModifier::new();
+    actual_modifier.add_super();
+    actual_modifier.add_control();
+    assert_eq!(hotkey.is_match(actual_modifier, &' '), true);
+
+    actual_modifier.add_capslock();
+    assert!(hotkey.is_match(actual_modifier, &' '));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ fn event_handler(handle: Handle, keycode: Option<char>, modifiers: KeyModifier) 
     unsafe {
         match keycode {
             Some(keycode) => {
-                if INPUT_STATE.get_hotkey().is_match(modifiers, &keycode) {
+                let is_hotkey_pressed = INPUT_STATE.get_hotkey().is_match(modifiers, &keycode);
+
+                if is_hotkey_pressed {
                     INPUT_STATE.toggle_vietnamese();
                     if let Some(event_sink) = UI_EVENT_SINK.get() {
                         _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
@@ -75,11 +77,13 @@ fn event_handler(handle: Handle, keycode: Option<char>, modifiers: KeyModifier) 
                                 {
                                     INPUT_STATE.new_word();
                                 } else if INPUT_STATE.is_tracking() {
-                                    INPUT_STATE.push(if modifiers.is_shift() {
-                                        c.to_ascii_uppercase()
-                                    } else {
-                                        c
-                                    });
+                                    INPUT_STATE.push(
+                                        if modifiers.is_shift() || modifiers.is_capslock() {
+                                            c.to_ascii_uppercase()
+                                        } else {
+                                            c
+                                        },
+                                    );
                                     if INPUT_STATE.should_transform_keys(&c) {
                                         return do_transform_keys(handle, false);
                                     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -150,10 +150,11 @@ pub fn run_event_listener(callback: &CallbackFn) {
                             as CGKeyCode;
                         let mut modifiers = KeyModifier::new();
                         let flags = event.get_flags();
-                        if flags.contains(CGEventFlags::CGEventFlagShift)
-                            || flags.contains(CGEventFlags::CGEventFlagAlphaShift)
-                        {
+                        if flags.contains(CGEventFlags::CGEventFlagShift) {
                             modifiers.add_shift();
+                        }
+                        if flags.contains(CGEventFlags::CGEventFlagAlphaShift) {
+                            modifiers.add_capslock();
                         }
                         if flags.contains(CGEventFlags::CGEventFlagControl) {
                             modifiers.add_control();

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -28,6 +28,7 @@ bitflags! {
         const MODIFIER_SUPER    = 0b00000010;
         const MODIFIER_CONTROL  = 0b00000100;
         const MODIFIER_ALT      = 0b00001000;
+        const MODIFIER_CAPSLOCK = 0b00010000;
     }
 }
 
@@ -45,6 +46,9 @@ impl Display for KeyModifier {
         if self.is_shift() {
             write!(f, "shift+")?;
         }
+        if self.is_capslock() {
+            write!(f, "capslock+")?;
+        }
         write!(f, "")
     }
 }
@@ -54,11 +58,19 @@ impl KeyModifier {
         Self { bits: 0 }
     }
 
-    pub fn apply(&mut self, is_super: bool, is_ctrl: bool, is_alt: bool, is_shift: bool) {
+    pub fn apply(
+        &mut self,
+        is_super: bool,
+        is_ctrl: bool,
+        is_alt: bool,
+        is_shift: bool,
+        is_capslock: bool,
+    ) {
         self.set(Self::MODIFIER_SUPER, is_super);
         self.set(Self::MODIFIER_CONTROL, is_ctrl);
         self.set(Self::MODIFIER_ALT, is_alt);
         self.set(Self::MODIFIER_SHIFT, is_shift);
+        self.set(Self::MODIFIER_CAPSLOCK, is_capslock);
     }
 
     pub fn add_shift(&mut self) {
@@ -77,6 +89,10 @@ impl KeyModifier {
         self.set(Self::MODIFIER_ALT, true);
     }
 
+    pub fn add_capslock(&mut self) {
+        self.set(Self::MODIFIER_CAPSLOCK, true);
+    }
+
     pub fn is_shift(&self) -> bool {
         self.contains(Self::MODIFIER_SHIFT)
     }
@@ -91,6 +107,10 @@ impl KeyModifier {
 
     pub fn is_alt(&self) -> bool {
         self.contains(Self::MODIFIER_ALT)
+    }
+
+    pub fn is_capslock(&self) -> bool {
+        self.contains(Self::MODIFIER_CAPSLOCK)
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -67,6 +67,7 @@ pub struct UIDataAdapter {
     ctrl_key: bool,
     alt_key: bool,
     shift_key: bool,
+    capslock_key: bool,
     letter_key: String,
     // system tray
     systray: SystemTray,
@@ -82,6 +83,7 @@ impl UIDataAdapter {
             ctrl_key: true,
             alt_key: false,
             shift_key: false,
+            capslock_key: false,
             letter_key: String::from("Space"),
             systray: SystemTray::new(),
         };
@@ -218,7 +220,13 @@ impl<W: Widget<UIDataAdapter>> Controller<UIDataAdapter, W> for UIController {
 
             if !data.letter_key.is_empty() {
                 let mut new_mod = KeyModifier::new();
-                new_mod.apply(data.super_key, data.ctrl_key, data.alt_key, data.shift_key);
+                new_mod.apply(
+                    data.super_key,
+                    data.ctrl_key,
+                    data.alt_key,
+                    data.shift_key,
+                    data.capslock_key,
+                );
                 let key_code = letter_key_to_char(&data.letter_key);
                 if !INPUT_STATE.get_hotkey().is_match(new_mod, &key_code) {
                     INPUT_STATE.set_hotkey(&format!(


### PR DESCRIPTION
Fix the issue https://github.com/huytd/goxkey/issues/49 where users cannot toggle VN mode with hotkey when Caps Lock is on.

### Cause

In current implementation, when Caps Lock is on, it is assumed that Shift key is pressed. If user presses a configured hotkey, says, `Ctrl+Super+Space`, it is eventually interpreted as `Ctrl+Shift+Super+Space`. This does not match with the configured hotkey hence the hotkey handler is not triggered.

### Solution

- Update `KeyModifier` struct to support Caps Lock as a modifier so it can clearly tell whether Shift or Caps Lock is pressed.
- Update `Hotkey` to ignore Caps Lock key so Caps Lock key won't interfere with any hotkey.