### PR TITLE
Thêm chức năng khởi động cùng hệ điều hành

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs",
+ "thiserror",
+ "winreg",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +348,26 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "displaydoc"
@@ -674,6 +705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gio"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +812,7 @@ version = "0.1.2"
 dependencies = [
  "accessibility",
  "accessibility-sys",
+ "auto-launch",
  "bitflags 1.3.2",
  "cocoa 0.24.1",
  "core-foundation 0.9.3",
@@ -1417,6 +1460,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ vi = { git = "https:/github.com/zerox-dg/vi-rs", branch = "master" }
 bitflags = "1.3.2"
 druid = { version = "0.8.2", features = ["image", "png"] }
 once_cell = "1.17.0"
+auto-launch = "0.5.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.9.3"

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -35,3 +35,11 @@ pub fn ensure_accessibility_permission() -> bool {
 pub fn is_in_text_selection() -> bool {
     todo!()
 }
+
+pub fn update_launch_on_login(is_enable: bool) {
+    todo!()
+}
+
+pub fn is_launch_on_login() {
+    todo!()
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::{env, path::PathBuf, ptr};
 
 mod macos_ext;
-use auto_launch::AutoLaunch;
+use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 use cocoa::base::id;
 use cocoa::{
     base::{nil, YES},
@@ -48,11 +48,17 @@ pub const SYMBOL_ALT: &str = "⌥";
 pub const HIDE_COMMAND: Selector = HIDE_APPLICATION;
 static AUTO_LAUNCH: Lazy<AutoLaunch> = Lazy::new(|| {
     let app_path = get_active_app_name();
-    let app_name = Path::new(&app_path)
+    let app_path = app_path.as_str();
+    let app_name = Path::new(app_path)
         .file_stem()
         .and_then(|f| f.to_str())
         .unwrap();
-    AutoLaunch::new(app_name, app_path.as_str(), false, &[] as &[&str])
+    AutoLaunchBuilder::new()
+        .set_app_name(app_name)
+        .set_app_path(app_path)
+        .set_use_launch_agent(true)
+        .build()
+        .unwrap()
 });
 
 #[macro_export]

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{env, path::PathBuf, ptr};
 
 mod macos_ext;
@@ -46,13 +47,12 @@ pub const SYMBOL_ALT: &str = "⌥";
 
 pub const HIDE_COMMAND: Selector = HIDE_APPLICATION;
 static AUTO_LAUNCH: Lazy<AutoLaunch> = Lazy::new(|| {
-    let app_path = std::env::current_exe().unwrap();
-    let app_name = app_path
-        .as_path()
+    let app_path = get_active_app_name();
+    let app_name = Path::new(&app_path)
         .file_stem()
         .and_then(|f| f.to_str())
         .unwrap();
-    AutoLaunch::new(app_name, app_path.to_str().unwrap(), true, &[] as &[&str])
+    AutoLaunch::new(app_name, app_path.as_str(), false, &[] as &[&str])
 });
 
 #[macro_export]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,8 +8,8 @@ use std::fmt::Display;
 use bitflags::bitflags;
 pub use os::{
     ensure_accessibility_permission, get_active_app_name, get_home_dir, is_in_text_selection,
-    run_event_listener, send_backspace, send_string, Handle, HIDE_COMMAND, SYMBOL_ALT, SYMBOL_CTRL,
-    SYMBOL_SHIFT, SYMBOL_SUPER,
+    is_launch_on_login, run_event_listener, send_backspace, send_string, update_launch_on_login,
+    Handle, HIDE_COMMAND, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 #[cfg(target_os = "macos")]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -40,3 +40,11 @@ pub fn ensure_accessibility_permission() -> bool {
 pub fn is_in_text_selection() -> bool {
     todo!()
 }
+
+pub fn update_launch_on_login(is_enable: bool) {
+    todo!()
+}
+
+pub fn is_launch_on_login() {
+    todo!()
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ use druid::{
     },
     Application, Data, Env, Event, EventCtx, ImageBuf, Lens, Selector, Target, Widget, WidgetExt,
 };
+use log::error;
 
 pub const UPDATE_UI: Selector = Selector::new("gox-ui.update-ui");
 
@@ -222,7 +223,9 @@ impl<W: Widget<UIDataAdapter>> Controller<UIDataAdapter, W> for UIController {
             }
 
             if old_data.launch_on_login != data.launch_on_login {
-                _ = update_launch_on_login(data.launch_on_login);
+                if let Err(err) = update_launch_on_login(data.launch_on_login) {
+                    error!("{}", err);
+                }
             }
 
             if !data.letter_key.is_empty() {


### PR DESCRIPTION
# Issue
https://github.com/huytd/goxkey/issues/44

# Solution

- Use crate auto-launch (which also supports linux and windows should we add those platforms later)
  - Use AppleScript to add/remove the app to/fro  Login Items

<img width="400" alt="image" src="https://github.com/huytd/goxkey/assets/30631476/0f63dd2e-104c-47a4-803c-bf17ceb1258e">


- Add an UI toggle
<img width="337" alt="image" src="https://github.com/huytd/goxkey/assets/30631476/0931f831-0495-46de-91ac-bb35e2439e01">

