### PR TITLE
bug: can't write consecutive d's

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -17,9 +17,9 @@ use crate::{
 // be around 10 to 12.
 const MAX_POSSIBLE_WORD_LENGTH: usize = 10;
 const MAX_DUPLICATE_LENGTH: usize = 4;
-const TONE_DUPLICATE_PATTERNS: [&str; 16] = [
+const TONE_DUPLICATE_PATTERNS: [&str; 17] = [
     "ss", "ff", "jj", "rr", "xx", "ww", "kk", "tt", "nn", "mm", "yy", "hh", "ii", "aaa", "eee",
-    "ooo",
+    "ooo", "ddd",
 ];
 
 pub static mut INPUT_STATE: Lazy<InputState> = Lazy::new(InputState::new);


### PR DESCRIPTION
# Issue

Can't write "ddddddddddd...". Stuck at "đd" until reaching max word length.

https://github.com/huytd/goxkey/assets/30631476/f231d795-9b2a-40b0-863e-65c10c2d6f7f

This is an upstream bug at https://github.com/ZeroX-DG/vi-rs/issues/30. But similar to the logic of `ooo`, we might still want to optimize by stop tracking at `ddd`

# Solution

Add "ddd" to `TONE_DUPLICATE_PATTERNS` to bail out fast (similar to "ooo" or "aaa")