### PR TITLE
feat: Implement a proper show/hide UI function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,8 +383,7 @@ dependencies = [
 [[package]]
 name = "druid"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ece41814b410c87e6379441caa7316539500b2e387b8d691f2ba5c0f4aff631"
+source = "git+https://github.com/huytd/druid?branch=master#ff762386f6de691bd96a36254fbe2f3a335e3cd3"
 dependencies = [
  "console_error_panic_hook",
  "druid-derive",
@@ -405,8 +404,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808d664482b1888a2ccb7f4dc9fa24165174d65ba96726315964064bdbc7d6cb"
+source = "git+https://github.com/huytd/druid?branch=master#ff762386f6de691bd96a36254fbe2f3a335e3cd3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -416,8 +414,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7682d9c8fbf934504c30970775bfcfba7858a600f2f6e56bed331989958350fc"
+source = "git+https://github.com/huytd/druid?branch=master#ff762386f6de691bd96a36254fbe2f3a335e3cd3"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ version = "0.1.2"
 env_logger = "0.10.0"
 libc = "0.2.139"
 log = "0.4.17"
-vi = { git = "https:/github.com/zerox-dg/vi-rs", branch = "master" }
+vi = { git = "https://github.com/zerox-dg/vi-rs", branch = "master" }
 bitflags = "1.3.2"
-druid = { version = "0.8.2", features = ["image", "png"] }
+druid = { features = ["image", "png"], git = "https://github.com/huytd/druid", branch = "master" }
 once_cell = "1.17.0"
 auto-launch = "0.5.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ fn main() {
             .title("gõkey")
             .window_size((ui::WINDOW_WIDTH, ui::WINDOW_HEIGHT))
             .set_position(ui::center_window_position())
+            .set_always_on_top(true)
             .resizable(false);
         let app = AppLauncher::with_window(win);
         let event_sink = app.get_external_handle();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -9,9 +9,6 @@ pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "❖";
 pub const SYMBOL_ALT: &str = "⌥";
 
-// TODO: support HIDE_WINDOW on next druid future versions
-pub const HIDE_COMMAND: Selector = CLOSE_WINDOW;
-
 pub fn get_home_dir() -> Option<PathBuf> {
     env::var("HOME").ok().map(PathBuf::from)
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -16,7 +16,6 @@ use core_graphics::{
     },
     sys,
 };
-use druid::{commands::HIDE_APPLICATION, Selector};
 use objc::{class, msg_send, sel, sel_impl};
 
 pub use macos_ext::SystemTray;
@@ -46,7 +45,6 @@ pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "⌘";
 pub const SYMBOL_ALT: &str = "⌥";
 
-pub const HIDE_COMMAND: Selector = HIDE_APPLICATION;
 static AUTO_LAUNCH: Lazy<AutoLaunch> = Lazy::new(|| {
     let app_path = get_current_app_path();
     let app_name = Path::new(&app_path)

--- a/src/platform/macos_ext.rs
+++ b/src/platform/macos_ext.rs
@@ -1,6 +1,4 @@
-use cocoa::appkit::{
-    NSApp, NSApplication, NSButton, NSMenu, NSMenuItem, NSStatusBar, NSStatusItem,
-};
+use cocoa::appkit::{NSApp, NSApplication, NSButton, NSMenu, NSMenuItem, NSStatusBar, NSStatusItem};
 use cocoa::base::{nil, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSString};
 use core_foundation::dictionary::CFDictionaryRef;
@@ -31,6 +29,7 @@ impl Data for Wrapper {
 }
 
 pub enum SystemTrayMenuItemKey {
+    ShowUI,
     Enable,
     TypingMethodTelex,
     TypingMethodVNI,
@@ -75,6 +74,8 @@ impl SystemTray {
     }
 
     pub fn init_menu_items(&self) {
+        self.add_menu_item("Bật bảng điều khiển", || ());
+        self.add_menu_separator();
         self.add_menu_item("Tắt gõ tiếng việt", || ());
         self.add_menu_separator();
         self.add_menu_item("Telex ✓", || ());
@@ -109,10 +110,11 @@ impl SystemTray {
 
     pub fn get_menu_item_index_by_key(&self, key: SystemTrayMenuItemKey) -> i64 {
         match key {
-            SystemTrayMenuItemKey::Enable => 0,
-            SystemTrayMenuItemKey::TypingMethodTelex => 2,
-            SystemTrayMenuItemKey::TypingMethodVNI => 3,
-            SystemTrayMenuItemKey::Exit => 5,
+            SystemTrayMenuItemKey::ShowUI => 0,
+            SystemTrayMenuItemKey::Enable => 2,
+            SystemTrayMenuItemKey::TypingMethodTelex => 4,
+            SystemTrayMenuItemKey::TypingMethodVNI => 5,
+            SystemTrayMenuItemKey::Exit => 7,
         }
     }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,7 +9,7 @@ use bitflags::bitflags;
 pub use os::{
     ensure_accessibility_permission, get_active_app_name, get_home_dir, is_in_text_selection,
     is_launch_on_login, run_event_listener, send_backspace, send_string, update_launch_on_login,
-    Handle, HIDE_COMMAND, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
+    Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 #[cfg(target_os = "macos")]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -9,9 +9,6 @@ pub const SYMBOL_CTRL: &str = "⌃";
 pub const SYMBOL_SUPER: &str = "⊞";
 pub const SYMBOL_ALT: &str = "⌥";
 
-// TODO: support HIDE_WINDOW on next druid future versions
-pub const HIDE_COMMAND: Selector = CLOSE_WINDOW;
-
 pub fn get_home_dir() -> Option<PathBuf> {
     env::var("USERPROFILE").ok().map(PathBuf::from)
         .or_else(|| env::var("HOMEDRIVE").ok().and_then(|home_drive| {


### PR DESCRIPTION
<img width="186" alt="image" src="https://github.com/huytd/goxkey/assets/613943/5a94b2fb-d301-4aeb-a5e4-4c3eeb8f3f7a">

Hide the app icon from the dock bar, and add a new menu item to show UI again after hide.

Fixes #85

---

Most importantly, I'm forking Druid to fix some default behaviors, since the mainstream's development has stopped.
