### PR TITLE
Fix auto vnese toggle lags behind

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,9 @@ use input::{rebuild_keyboard_layout_map, INPUT_STATE};
 use log::debug;
 use once_cell::sync::OnceCell;
 use platform::{
-    ensure_accessibility_permission, run_event_listener, send_backspace, send_string, Handle,
-    KeyModifier, PressedKey, KEY_DELETE, KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_TAB, RAW_KEY_GLOBE,
+    add_app_change_callback, ensure_accessibility_permission, run_event_listener, send_backspace,
+    send_string, Handle, KeyModifier, PressedKey, KEY_DELETE, KEY_ENTER, KEY_ESCAPE, KEY_SPACE,
+    KEY_TAB, RAW_KEY_GLOBE,
 };
 
 use ui::{UIDataAdapter, UPDATE_UI};
@@ -88,7 +89,6 @@ unsafe fn auto_toggle_vietnamese() {
 
 fn event_handler(handle: Handle, pressed_key: Option<PressedKey>, modifiers: KeyModifier) -> bool {
     unsafe {
-        auto_toggle_vietnamese();
         let pressed_key_code = pressed_key.and_then(|p| match p {
             PressedKey::Char(c) => Some(c),
             _ => None,
@@ -206,6 +206,9 @@ fn main() {
         _ = UI_EVENT_SINK.set(event_sink);
         thread::spawn(|| {
             run_event_listener(&event_handler);
+        });
+        add_app_change_callback(|| {
+            unsafe { auto_toggle_vietnamese() };
         });
         _ = app.launch(UIDataAdapter::new());
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -207,6 +207,13 @@ pub fn send_string(handle: Handle, string: &str) -> Result<(), ()> {
     Ok(())
 }
 
+pub fn add_app_change_callback<F>(cb: F)
+where
+    F: Fn() + Send + 'static,
+{
+    macos_ext::add_app_change_callback(cb);
+}
+
 pub fn run_event_listener(callback: &CallbackFn) {
     let current = CFRunLoop::get_current();
     if let Ok(event_tap) = new_tap::CGEventTap::new(

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,9 +7,9 @@ use std::fmt::Display;
 
 use bitflags::bitflags;
 pub use os::{
-    ensure_accessibility_permission, get_active_app_name, get_home_dir, is_in_text_selection,
-    is_launch_on_login, run_event_listener, send_backspace, send_string, update_launch_on_login,
-    Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
+    add_app_change_callback, ensure_accessibility_permission, get_active_app_name, get_home_dir,
+    is_in_text_selection, is_launch_on_login, run_event_listener, send_backspace, send_string,
+    update_launch_on_login, Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
# Issue

- Fixes https://github.com/huytd/goxkey/issues/101
- Khi chuyển app (có chế độ gõ tiếng việt khác nhau), phải thao tác (gõ, click) một vài lần thì bộ gõ mới update

# Cause

Hiện tại, khi detect click/type, app sẽ lập tức check `frontmostApplication` để quyết định có toggle vnese hay không.
Nhưng lúc này value `frontmostApplication` chưa cập nhật kịp, đó là lí do tại sao phải thao tác click/type thêm 1 lần nữa ( aka trigger check sau 1 lúc) thì mới update.

# Solution

Subscribe vào event `NSWorkspaceDidActivateApplicationNotification` để trigger auto toggle vietnamese