### PR TITLE
[Feature] switching unix socket for command-line

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -160,7 +160,7 @@ pub struct InputState {
     is_macro_enabled: bool,
     macro_table: BTreeMap<String, String>,
     temporary_disabled: bool,
-    previous_modifiers: KeyModifier
+    previous_modifiers: KeyModifier,
 }
 
 impl InputState {
@@ -178,7 +178,7 @@ impl InputState {
             is_macro_enabled: config.is_macro_enabled(),
             macro_table: config.get_macro_table().clone(),
             temporary_disabled: false,
-            previous_modifiers: KeyModifier::empty()
+            previous_modifiers: KeyModifier::empty(),
         }
     }
 
@@ -246,8 +246,8 @@ impl InputState {
         self.should_track = false;
     }
 
-    pub fn toggle_vietnamese(&mut self) {
-        self.enabled = !self.enabled;
+    pub fn set_enabled(&mut self, value: bool) {
+        self.enabled = value;
         self.temporary_disabled = false;
         let mut config = CONFIG_MANAGER.lock().unwrap();
         if self.enabled {
@@ -256,6 +256,10 @@ impl InputState {
             config.add_english_app(&self.active_app);
         }
         self.new_word();
+    }
+
+    pub fn toggle_vietnamese(&mut self) {
+        self.set_enabled(!self.enabled)
     }
 
     pub fn set_method(&mut self, method: TypingMethod) {


### PR DESCRIPTION
Hi tác giả,

Mình mở PR này để giải quyết cái issue nhỏ khi làm việc với Vim, background mình không phải là Rust dev nên code có dở thì tác giả góp ý nhé.

Ref Issue : https://github.com/huytd/goxkey/issues/89

IDEA : Mình sẽ open 1 UNIX socket (sau này có thể bật qua UI settings), mở socket ở file `/tmp/gox-switch-socket` (do mở = User run app nên quyền access cũng thuộc chung về User)

Khi cần switch thẳng mode (vi or en) thì mình dùng 1 client (bằng bất kỳ ngôn ngữ hoặc tool có thể send packet đến UNIX socket, nếu là bash thì macos có tool `socat`)

```bash
$ echo "vi" | socat - UNIX-CONNECT:/tmp/gox-switch-socket
done
$ echo "en" | socat - UNIX-CONNECT:/tmp/gox-switch-socket
done
```

Note : mình có bundle và test thử thì đã work, nhưng còn 1 lỗi nhỏ là khi switch thì cái system tray value nó không update, có thể chưa gửi event update UI (này thật tình mình không rành kiến trúc rust và mac-ui)

Chúc tác giả 1 năm mới nhiều may mắn nhé, cảm ơn đã tạo ra 1 bộ gõ tốt cho người Việt.