### PR TITLE
fix: extend selection dismiss workaround to Firefox-based browsers

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -364,7 +364,8 @@ impl InputState {
     }
 
     pub fn should_dismiss_selection_if_needed(&self) -> bool {
-        return self.active_app.contains("Firefox");
+        const DISMISS_APPS: [&str; 2] = ["Firefox", "Floorp"];
+        return DISMISS_APPS.iter().any(|app| self.active_app.contains(app));
     }
 
     pub fn get_backspace_count(&self, is_delete: bool) -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn do_transform_keys(handle: Handle, is_delete: bool) -> bool {
         if let Ok((output, transform_result)) = INPUT_STATE.transform_keys() {
             debug!("Transformed: {:?}", output);
             if INPUT_STATE.should_send_keyboard_event(&output) || is_delete {
-                // This is a workaround for Firefox, where macOS's Accessibility API cannot work.
+                // This is a workaround for Firefox-based browsers, where macOS's Accessibility API cannot work.
                 // We cannot get the selected text in the address bar, so we will go with another
                 // hacky way: Always send a space and delete it immediately. This will dismiss the
                 // current pre-selected URL and fix the double character issue.


### PR DESCRIPTION
- Support Firefox and Floorp in should_dismiss_selection_if_needed
- Use const for the dismiss app list to avoid per-call reallocation
- Update comment in main.rs to say "Firefox-based browsers"

Fix issue from https://github.com/huytd/goxkey/issues/118, https://github.com/huytd/goxkey/issues/123