### PR TITLE
fix: use correct macOS API for systray icon title updates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,9 @@ fn do_macro_replace(handle: Handle, target: &String) {
 unsafe fn toggle_vietnamese() {
     INPUT_STATE.toggle_vietnamese();
     if let Some(event_sink) = UI_EVENT_SINK.get() {
-        _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
+        if let Err(e) = event_sink.submit_command(UPDATE_UI, (), Target::Auto) {
+            debug!("Failed to submit UPDATE_UI command: {:?}", e);
+        }
     }
 }
 
@@ -136,7 +138,9 @@ unsafe fn auto_toggle_vietnamese() {
         return;
     }
     if let Some(event_sink) = UI_EVENT_SINK.get() {
-        _ = event_sink.submit_command(UPDATE_UI, (), Target::Auto);
+        if let Err(e) = event_sink.submit_command(UPDATE_UI, (), Target::Auto) {
+            debug!("Failed to submit UPDATE_UI command: {:?}", e);
+        }
     }
 }
 

--- a/src/platform/macos_ext.rs
+++ b/src/platform/macos_ext.rs
@@ -55,7 +55,8 @@ impl SystemTray {
             app.activateIgnoringOtherApps_(YES);
             let item = NSStatusBar::systemStatusBar(nil).statusItemWithLength_(-1.0);
             let title = NSString::alloc(nil).init_str("VN");
-            NSButton::setTitle_(item, title);
+            let button: id = msg_send![item, button];
+            let _: () = msg_send![button, setTitle: title];
             item.setMenu_(menu);
 
             let s = Self {
@@ -70,9 +71,10 @@ impl SystemTray {
 
     pub fn set_title(&mut self, title: &str) {
         unsafe {
-            let title = NSString::alloc(nil).init_str(title);
-            NSButton::setTitle_(self.item.0, title);
-            let _: () = msg_send![title, release];
+            let title_str = NSString::alloc(nil).init_str(title);
+            let button: id = msg_send![self.item.0, button];
+            let _: () = msg_send![button, setTitle: title_str];
+            let _: () = msg_send![title_str, release];
         }
     }
 
@@ -125,7 +127,9 @@ impl SystemTray {
         unsafe {
             let item_title = NSString::alloc(nil).init_str(label);
             let index = self.get_menu_item_index_by_key(key);
-            NSButton::setTitle_(self.menu.0.itemAtIndex_(index), item_title);
+            let menu_item: id = msg_send![self.menu.0, itemAtIndex: index];
+            let _: () = msg_send![menu_item, setTitle: item_title];
+            let _: () = msg_send![item_title, release];
         }
     }
 


### PR DESCRIPTION
- Use NSStatusItem.button property for set_title() instead of calling NSButton::setTitle_ directly on the NSStatusItem object
- Fix set_menu_item_title() to use msg_send![item, setTitle:] instead of NSButton::setTitle_ on NSMenuItem
- Fix initial title setup in SystemTray::new() same way
- Log errors on UPDATE_UI command submission failure instead of silently discarding with _ =