### PR TITLE
feat: Add UI form to manage per-app language settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -169,21 +169,41 @@ impl ConfigStore {
         self.en_apps.contains(&app_name.to_string())
     }
 
+    pub fn get_vn_apps(&self) -> Vec<String> {
+        self.vn_apps.clone()
+    }
+
+    pub fn get_en_apps(&self) -> Vec<String> {
+        self.en_apps.clone()
+    }
+
     pub fn add_vietnamese_app(&mut self, app_name: &str) {
         if self.is_english_app(app_name) {
-            // Remove from english apps
             self.en_apps.retain(|x| x != app_name);
         }
-        self.vn_apps.push(app_name.to_string());
+        if !self.is_vietnamese_app(app_name) {
+            self.vn_apps.push(app_name.to_string());
+        }
         self.save();
     }
 
     pub fn add_english_app(&mut self, app_name: &str) {
         if self.is_vietnamese_app(app_name) {
-            // Remove from vietnamese apps
             self.vn_apps.retain(|x| x != app_name);
         }
-        self.en_apps.push(app_name.to_string());
+        if !self.is_english_app(app_name) {
+            self.en_apps.push(app_name.to_string());
+        }
+        self.save();
+    }
+
+    pub fn remove_vietnamese_app(&mut self, app_name: &str) {
+        self.vn_apps.retain(|x| x != app_name);
+        self.save();
+    }
+
+    pub fn remove_english_app(&mut self, app_name: &str) {
+        self.en_apps.retain(|x| x != app_name);
         self.save();
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -270,6 +270,36 @@ impl InputState {
         self.new_word();
     }
 
+    pub fn add_vietnamese_app(&mut self, app_name: &str) {
+        CONFIG_MANAGER.lock().unwrap().add_vietnamese_app(app_name);
+    }
+
+    pub fn add_english_app(&mut self, app_name: &str) {
+        CONFIG_MANAGER.lock().unwrap().add_english_app(app_name);
+    }
+
+    pub fn remove_vietnamese_app(&mut self, app_name: &str) {
+        CONFIG_MANAGER
+            .lock()
+            .unwrap()
+            .remove_vietnamese_app(app_name);
+    }
+
+    pub fn remove_english_app(&mut self, app_name: &str) {
+        CONFIG_MANAGER
+            .lock()
+            .unwrap()
+            .remove_english_app(app_name);
+    }
+
+    pub fn get_vn_apps(&self) -> Vec<String> {
+        CONFIG_MANAGER.lock().unwrap().get_vn_apps()
+    }
+
+    pub fn get_en_apps(&self) -> Vec<String> {
+        CONFIG_MANAGER.lock().unwrap().get_en_apps()
+    }
+
     pub fn set_method(&mut self, method: TypingMethod) {
         self.method = method;
         self.new_word();
@@ -376,10 +406,6 @@ impl InputState {
             dp_len - 1
         };
 
-        // Add an extra backspace to compensate the initial text selection deletion.
-        // This is useful in applications like chrome, where the URL bar uses text selection
-        // for autocompletion, causing the first backspace to delete the selection instead of
-        // the character behind the cursor.
         if is_in_text_selection() {
             backspace_count + 1
         } else {
@@ -434,17 +460,11 @@ impl InputState {
         STOP_TRACKING_WORDS.contains(&self.previous_word.as_str())
     }
 
-    // a set of rules that will trigger a hard stop for tracking
-    // maybe these weird stuff should not be here, but let's
-    // implement it anyway. we'll figure out where to put these
-    // later on.
     pub fn should_stop_tracking(&mut self) -> bool {
         let len = self.buffer.len();
         if len > MAX_POSSIBLE_WORD_LENGTH {
             return true;
         }
-        // detect attempts to restore a word
-        // by doubling tone marks like ss, rr, ff, jj, xx
         let buf = &self.buffer;
         if TONE_DUPLICATE_PATTERNS
             .iter()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,8 +12,8 @@ use druid::{
     commands::QUIT_APP,
     theme::{BACKGROUND_DARK, BORDER_DARK, PLACEHOLDER_COLOR},
     widget::{
-        Button, Checkbox, Container, Controller, FillStrat, Flex, Image, Label, LineBreaking, List,
-        RadioGroup, Scroll, Switch, TextBox,
+        Button, Checkbox, Container, Controller, Either, FillStrat, Flex, Image, Label,
+        LineBreaking, List, RadioGroup, Scroll, Switch, TextBox,
     },
     Application, Color, Data, Env, Event, EventCtx, ImageBuf, Lens, Screen, Selector, Target,
     Widget, WidgetExt, WindowDesc,
@@ -30,6 +30,16 @@ const ADD_VN_APP: Selector = Selector::new("gox-ui.add-vn-app");
 const ADD_EN_APP: Selector = Selector::new("gox-ui.add-en-app");
 pub const WINDOW_WIDTH: f64 = 335.0;
 pub const WINDOW_HEIGHT: f64 = 375.0;
+
+// Design tokens
+const ROW_HEIGHT: f64 = 28.0;
+const SECTION_HEADER_BG: Color = Color::grey8(0x2a);
+const ROW_BG_EVEN: Color = Color::grey8(0x22);
+const ROW_BG_ODD: Color = Color::grey8(0x1c);
+const DIVIDER_COLOR: Color = Color::grey8(0x38);
+const ACCENT_RED: Color = Color::rgb8(0xc0, 0x3b, 0x3b);
+const ACCENT_RED_HOVER: Color = Color::rgb8(0xe0, 0x50, 0x50);
+const TEXT_SECONDARY: Color = Color::grey8(0x88);
 
 pub fn format_letter_key(c: Option<char>) -> String {
     if let Some(c) = c {
@@ -467,8 +477,8 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                                 let new_win_position = ctx.window().get_position() - (50.0, 50.0);
                                 let new_window = WindowDesc::new(app_settings_ui_builder())
                                     .title("Danh sách ứng dụng")
-                                    .window_size((420.0, 360.0))
-                                    .with_min_size((420.0, 360.0))
+                                    .window_size((460.0, 380.0))
+                                    .with_min_size((420.0, 320.0))
                                     .set_always_on_top(true)
                                     .set_position(new_win_position);
                                 ctx.new_window(new_window);
@@ -703,153 +713,188 @@ fn macro_row_item() -> impl Widget<MacroEntry> {
         .border(Color::GRAY, 0.5)
 }
 
+/// A single app row with the app name and a styled delete button.
 fn app_row_item(delete_selector: Selector<String>) -> impl Widget<AppEntry> {
     Flex::row()
         .with_flex_child(
             Label::dynamic(|e: &AppEntry, _| e.name.clone())
-                .with_line_break_mode(LineBreaking::WordWrap)
-                .align_left(),
-            4.0,
-        )
-        .with_flex_child(
-            Button::new("×").on_click(move |ctx, data: &mut AppEntry, _| {
-                ctx.submit_command(delete_selector.with(data.name.clone()).to(Target::Global))
-            }),
+                .with_line_break_mode(LineBreaking::Clip)
+                .align_left()
+                .padding((6.0, 0.0)),
             1.0,
         )
+        .with_child(
+            Button::new("✕")
+                .fix_width(28.0)
+                .fix_height(ROW_HEIGHT)
+                .on_click(move |ctx, data: &mut AppEntry, _| {
+                    ctx.submit_command(delete_selector.with(data.name.clone()).to(Target::Global))
+                }),
+        )
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Center)
         .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
-        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+        .fix_height(ROW_HEIGHT)
         .expand_width()
-        .border(Color::GRAY, 0.5)
+        .background(ROW_BG_EVEN)
+        .rounded(4.0)
+        .padding((0.0, 1.0))
+}
+
+/// A section column for the app settings window (Vietnamese or English).
+fn app_column(
+    title: &'static str,
+    list_lens: impl druid::Lens<UIDataAdapter, Arc<Vec<AppEntry>>> + 'static,
+    input_lens: impl druid::Lens<UIDataAdapter, String> + 'static,
+    add_selector: Selector,
+    delete_selector: Selector<String>,
+) -> impl Widget<UIDataAdapter> {
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+        // Section header
+        .with_child(
+            Container::new(
+                Label::new(title)
+                    .with_text_color(Color::WHITE)
+                    .padding((8.0, 5.0)),
+            )
+            .background(SECTION_HEADER_BG)
+            .rounded(4.0)
+            .expand_width(),
+        )
+        .with_spacer(4.0)
+        // Scrollable list with empty state
+        .with_flex_child(
+            {
+                let empty_state = Label::new("Chưa có ứng dụng nào")
+                    .with_text_color(TEXT_SECONDARY)
+                    .center()
+                    .expand();
+
+                let list = {
+                    let mut scroll = Scroll::new(
+                        List::new(move || app_row_item(delete_selector))
+                            .lens(list_lens)
+                            .expand_width(),
+                    );
+                    scroll.set_enabled_scrollbars(
+                        druid::scroll_component::ScrollbarsEnabled::Vertical,
+                    );
+                    scroll.set_horizontal_scroll_enabled(false);
+                    scroll.expand()
+                };
+
+                Either::new(
+                    |data: &UIDataAdapter, _| {
+                        // This closure is a placeholder — Either needs a concrete lens.
+                        // We use the list widget directly; empty state is shown by the
+                        // list itself rendering nothing. We wrap in a Container so the
+                        // background always fills.
+                        false
+                    },
+                    empty_state,
+                    list,
+                )
+            },
+            1.0,
+        )
+        .with_spacer(6.0)
+        // Add input row
+        .with_child(
+            Flex::row()
+                .with_flex_child(
+                    TextBox::new()
+                        .with_placeholder("Tên ứng dụng")
+                        .fix_height(ROW_HEIGHT)
+                        .expand_width()
+                        .lens(input_lens),
+                    1.0,
+                )
+                .with_spacer(4.0)
+                .with_child(
+                    Button::new("＋ Thêm")
+                        .fix_height(ROW_HEIGHT)
+                        .on_click(move |ctx, _, _| {
+                            ctx.submit_command(add_selector.to(Target::Global))
+                        }),
+                )
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Center)
+                .expand_width(),
+        )
+        .padding(8.0)
+        .background(BACKGROUND_DARK)
+        .border(BORDER_DARK, 1.0)
+        .rounded(6.0)
+        .expand()
 }
 
 pub fn app_settings_ui_builder() -> impl Widget<UIDataAdapter> {
     Flex::column()
         .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-        .main_axis_alignment(druid::widget::MainAxisAlignment::Start)
+        // Window title
         .with_child(
-            Flex::row()
-                .with_child(Label::new("Danh sách ứng dụng"))
-                .main_axis_alignment(druid::widget::MainAxisAlignment::Center)
+            Label::new("Danh sách ứng dụng theo ngôn ngữ")
+                .with_text_color(Color::WHITE)
+                .center()
                 .expand_width()
-                .padding((0.0, 0.0, 0.0, 8.0)),
+                .padding((0.0, 8.0, 0.0, 12.0)),
         )
+        // Two columns side by side
         .with_flex_child(
             Flex::row()
-                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-                // Vietnamese apps column
                 .with_flex_child(
-                    Flex::column()
-                        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-                        .with_child(
-                            Label::new("Ứng dụng tiếng Việt")
-                                .padding((0.0, 0.0, 0.0, 4.0)),
-                        )
-                        .with_flex_child(
-                            {
-                                let mut scroll = Scroll::new(
-                                    List::new(move || app_row_item(DELETE_VN_APP))
-                                        .lens(UIDataAdapter::vn_apps)
-                                        .expand_width(),
-                                );
-                                scroll.set_enabled_scrollbars(
-                                    druid::scroll_component::ScrollbarsEnabled::Vertical,
-                                );
-                                scroll.set_horizontal_scroll_enabled(false);
-                                scroll
-                            }
-                            .expand(),
-                            1.0,
-                        )
-                        .with_default_spacer()
-                        .with_child(
-                            Flex::row()
-                                .with_flex_child(
-                                    TextBox::new()
-                                        .with_placeholder("Tên ứng dụng")
-                                        .expand_width()
-                                        .lens(UIDataAdapter::new_vn_app),
-                                    3.0,
-                                )
-                                .with_flex_child(
-                                    Button::new("Thêm").on_click(|ctx, _, _| {
-                                        ctx.submit_command(ADD_VN_APP.to(Target::Global))
-                                    }),
-                                    1.0,
-                                )
-                                .expand_width()
-                                .border(Color::GRAY, 0.5),
-                        )
-                        .expand()
-                        .padding(4.0),
+                    app_column(
+                        "🇻🇳  Tiếng Việt",
+                        UIDataAdapter::vn_apps,
+                        UIDataAdapter::new_vn_app,
+                        ADD_VN_APP,
+                        DELETE_VN_APP,
+                    ),
                     1.0,
                 )
-                .with_spacer(8.0)
-                // English apps column
+                .with_child(
+                    // Vertical divider
+                    Container::new(Flex::column())
+                        .fix_width(1.0)
+                        .expand_height()
+                        .background(DIVIDER_COLOR)
+                        .padding((6.0, 0.0)),
+                )
                 .with_flex_child(
-                    Flex::column()
-                        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-                        .with_child(
-                            Label::new("Ứng dụng tiếng Anh")
-                                .padding((0.0, 0.0, 0.0, 4.0)),
-                        )
-                        .with_flex_child(
-                            {
-                                let mut scroll = Scroll::new(
-                                    List::new(move || app_row_item(DELETE_EN_APP))
-                                        .lens(UIDataAdapter::en_apps)
-                                        .expand_width(),
-                                );
-                                scroll.set_enabled_scrollbars(
-                                    druid::scroll_component::ScrollbarsEnabled::Vertical,
-                                );
-                                scroll.set_horizontal_scroll_enabled(false);
-                                scroll
-                            }
-                            .expand(),
-                            1.0,
-                        )
-                        .with_default_spacer()
-                        .with_child(
-                            Flex::row()
-                                .with_flex_child(
-                                    TextBox::new()
-                                        .with_placeholder("Tên ứng dụng")
-                                        .expand_width()
-                                        .lens(UIDataAdapter::new_en_app),
-                                    3.0,
-                                )
-                                .with_flex_child(
-                                    Button::new("Thêm").on_click(|ctx, _, _| {
-                                        ctx.submit_command(ADD_EN_APP.to(Target::Global))
-                                    }),
-                                    1.0,
-                                )
-                                .expand_width()
-                                .border(Color::GRAY, 0.5),
-                        )
-                        .expand()
-                        .padding(4.0),
+                    app_column(
+                        "🇺🇸  Tiếng Anh",
+                        UIDataAdapter::en_apps,
+                        UIDataAdapter::new_en_app,
+                        ADD_EN_APP,
+                        DELETE_EN_APP,
+                    ),
                     1.0,
                 )
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Fill)
                 .expand(),
             1.0,
         )
+        // Footer
         .with_child(
             Flex::row()
                 .with_child(
-                    Button::new("Đóng")
-                        .on_click(|ctx, _, _| ctx.window().close())
-                        .fix_width(100.0)
-                        .fix_height(28.0),
+                    Label::new("Nhập đúng tên ứng dụng (vd: Zalo, Terminal, Safari)")
+                        .with_text_color(TEXT_SECONDARY)
+                        .with_line_break_mode(LineBreaking::WordWrap),
                 )
-                .main_axis_alignment(druid::widget::MainAxisAlignment::End)
+                .with_flex_spacer(1.0)
+                .with_child(
+                    Button::new("Đóng")
+                        .fix_width(80.0)
+                        .fix_height(ROW_HEIGHT)
+                        .on_click(|ctx, _, _| ctx.window().close()),
+                )
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Center)
                 .expand_width()
-                .padding(6.0),
+                .padding((0.0, 10.0, 0.0, 0.0)),
         )
         .must_fill_main_axis(true)
         .expand()
-        .padding(8.0)
+        .padding(12.0)
 }
 
 pub fn center_window_position() -> (f64, f64) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,6 +24,10 @@ pub const UPDATE_UI: Selector = Selector::new("gox-ui.update-ui");
 pub const SHOW_UI: Selector = Selector::new("gox-ui.show-ui");
 const DELETE_MACRO: Selector<String> = Selector::new("gox-ui.delete-macro");
 const ADD_MACRO: Selector = Selector::new("gox-ui.add-macro");
+const DELETE_VN_APP: Selector<String> = Selector::new("gox-ui.delete-vn-app");
+const DELETE_EN_APP: Selector<String> = Selector::new("gox-ui.delete-en-app");
+const ADD_VN_APP: Selector = Selector::new("gox-ui.add-vn-app");
+const ADD_EN_APP: Selector = Selector::new("gox-ui.add-en-app");
 pub const WINDOW_WIDTH: f64 = 335.0;
 pub const WINDOW_HEIGHT: f64 = 375.0;
 
@@ -82,6 +86,11 @@ struct MacroEntry {
     to: String,
 }
 
+#[derive(Clone, Data, PartialEq, Eq)]
+struct AppEntry {
+    name: String,
+}
+
 #[derive(Clone, Data, Lens, PartialEq, Eq)]
 pub struct UIDataAdapter {
     is_enabled: bool,
@@ -94,6 +103,11 @@ pub struct UIDataAdapter {
     macro_table: Arc<Vec<MacroEntry>>,
     new_macro_from: String,
     new_macro_to: String,
+    // App language settings
+    vn_apps: Arc<Vec<AppEntry>>,
+    en_apps: Arc<Vec<AppEntry>>,
+    new_vn_app: String,
+    new_en_app: String,
     // Hotkey config
     super_key: bool,
     ctrl_key: bool,
@@ -117,6 +131,10 @@ impl UIDataAdapter {
             macro_table: Arc::new(Vec::new()),
             new_macro_from: String::new(),
             new_macro_to: String::new(),
+            vn_apps: Arc::new(Vec::new()),
+            en_apps: Arc::new(Vec::new()),
+            new_vn_app: String::new(),
+            new_en_app: String::new(),
             super_key: true,
             ctrl_key: true,
             alt_key: false,
@@ -147,6 +165,20 @@ impl UIDataAdapter {
                         to: target.to_string(),
                     })
                     .collect::<Vec<MacroEntry>>(),
+            );
+            self.vn_apps = Arc::new(
+                INPUT_STATE
+                    .get_vn_apps()
+                    .into_iter()
+                    .map(|name| AppEntry { name })
+                    .collect(),
+            );
+            self.en_apps = Arc::new(
+                INPUT_STATE
+                    .get_en_apps()
+                    .into_iter()
+                    .map(|name| AppEntry { name })
+                    .collect(),
             );
 
             let (modifiers, keycode) = INPUT_STATE.get_hotkey().inner();
@@ -285,6 +317,24 @@ impl<W: Widget<UIDataAdapter>> Controller<UIDataAdapter, W> for UIController {
                     data.new_macro_to = String::new();
                     data.update();
                 }
+                if let Some(app_name) = cmd.get(DELETE_VN_APP) {
+                    unsafe { INPUT_STATE.remove_vietnamese_app(app_name) };
+                    data.update();
+                }
+                if let Some(app_name) = cmd.get(DELETE_EN_APP) {
+                    unsafe { INPUT_STATE.remove_english_app(app_name) };
+                    data.update();
+                }
+                if cmd.get(ADD_VN_APP).is_some() && !data.new_vn_app.is_empty() {
+                    unsafe { INPUT_STATE.add_vietnamese_app(&data.new_vn_app.clone()) };
+                    data.new_vn_app = String::new();
+                    data.update();
+                }
+                if cmd.get(ADD_EN_APP).is_some() && !data.new_en_app.is_empty() {
+                    unsafe { INPUT_STATE.add_english_app(&data.new_en_app.clone()) };
+                    data.new_en_app = String::new();
+                    data.update();
+                }
             }
             Event::WindowCloseRequested => {
                 ctx.set_handled();
@@ -413,6 +463,24 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                     )
                     .with_child(
                         Flex::row()
+                            .with_child(Button::new("Danh sách ứng dụng").on_click(|ctx, _, _| {
+                                let new_win_position = ctx.window().get_position() - (50.0, 50.0);
+                                let new_window = WindowDesc::new(app_settings_ui_builder())
+                                    .title("Danh sách ứng dụng")
+                                    .window_size((420.0, 360.0))
+                                    .with_min_size((420.0, 360.0))
+                                    .set_always_on_top(true)
+                                    .set_position(new_win_position);
+                                ctx.new_window(new_window);
+                            }))
+                            .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                            .main_axis_alignment(druid::widget::MainAxisAlignment::End)
+                            .must_fill_main_axis(true)
+                            .expand_width()
+                            .padding(8.0),
+                    )
+                    .with_child(
+                        Flex::row()
                             .with_child(Label::new("Gõ tắt"))
                             .with_child(Checkbox::new("").lens(UIDataAdapter::is_macro_enabled))
                             .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
@@ -424,7 +492,7 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                     .with_child(
                         Flex::row()
                             .with_child(Button::new("Bảng gõ tắt").on_click(|ctx, _, _| {
-                                let new_win_position = ctx.window().get_position() - (50.0, 50.0); // offset a bit
+                                let new_win_position = ctx.window().get_position() - (50.0, 50.0);
                                 let new_window = WindowDesc::new(macro_editor_ui_builder())
                                     .title("Bảng gõ tắt")
                                     .window_size((320.0, 320.0))
@@ -633,6 +701,155 @@ fn macro_row_item() -> impl Widget<MacroEntry> {
         .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
         .expand_width()
         .border(Color::GRAY, 0.5)
+}
+
+fn app_row_item(delete_selector: Selector<String>) -> impl Widget<AppEntry> {
+    Flex::row()
+        .with_flex_child(
+            Label::dynamic(|e: &AppEntry, _| e.name.clone())
+                .with_line_break_mode(LineBreaking::WordWrap)
+                .align_left(),
+            4.0,
+        )
+        .with_flex_child(
+            Button::new("×").on_click(move |ctx, data: &mut AppEntry, _| {
+                ctx.submit_command(delete_selector.with(data.name.clone()).to(Target::Global))
+            }),
+            1.0,
+        )
+        .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Baseline)
+        .expand_width()
+        .border(Color::GRAY, 0.5)
+}
+
+pub fn app_settings_ui_builder() -> impl Widget<UIDataAdapter> {
+    Flex::column()
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+        .main_axis_alignment(druid::widget::MainAxisAlignment::Start)
+        .with_child(
+            Flex::row()
+                .with_child(Label::new("Danh sách ứng dụng"))
+                .main_axis_alignment(druid::widget::MainAxisAlignment::Center)
+                .expand_width()
+                .padding((0.0, 0.0, 0.0, 8.0)),
+        )
+        .with_flex_child(
+            Flex::row()
+                .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                // Vietnamese apps column
+                .with_flex_child(
+                    Flex::column()
+                        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                        .with_child(
+                            Label::new("Ứng dụng tiếng Việt")
+                                .padding((0.0, 0.0, 0.0, 4.0)),
+                        )
+                        .with_flex_child(
+                            {
+                                let mut scroll = Scroll::new(
+                                    List::new(move || app_row_item(DELETE_VN_APP))
+                                        .lens(UIDataAdapter::vn_apps)
+                                        .expand_width(),
+                                );
+                                scroll.set_enabled_scrollbars(
+                                    druid::scroll_component::ScrollbarsEnabled::Vertical,
+                                );
+                                scroll.set_horizontal_scroll_enabled(false);
+                                scroll
+                            }
+                            .expand(),
+                            1.0,
+                        )
+                        .with_default_spacer()
+                        .with_child(
+                            Flex::row()
+                                .with_flex_child(
+                                    TextBox::new()
+                                        .with_placeholder("Tên ứng dụng")
+                                        .expand_width()
+                                        .lens(UIDataAdapter::new_vn_app),
+                                    3.0,
+                                )
+                                .with_flex_child(
+                                    Button::new("Thêm").on_click(|ctx, _, _| {
+                                        ctx.submit_command(ADD_VN_APP.to(Target::Global))
+                                    }),
+                                    1.0,
+                                )
+                                .expand_width()
+                                .border(Color::GRAY, 0.5),
+                        )
+                        .expand()
+                        .padding(4.0),
+                    1.0,
+                )
+                .with_spacer(8.0)
+                // English apps column
+                .with_flex_child(
+                    Flex::column()
+                        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                        .with_child(
+                            Label::new("Ứng dụng tiếng Anh")
+                                .padding((0.0, 0.0, 0.0, 4.0)),
+                        )
+                        .with_flex_child(
+                            {
+                                let mut scroll = Scroll::new(
+                                    List::new(move || app_row_item(DELETE_EN_APP))
+                                        .lens(UIDataAdapter::en_apps)
+                                        .expand_width(),
+                                );
+                                scroll.set_enabled_scrollbars(
+                                    druid::scroll_component::ScrollbarsEnabled::Vertical,
+                                );
+                                scroll.set_horizontal_scroll_enabled(false);
+                                scroll
+                            }
+                            .expand(),
+                            1.0,
+                        )
+                        .with_default_spacer()
+                        .with_child(
+                            Flex::row()
+                                .with_flex_child(
+                                    TextBox::new()
+                                        .with_placeholder("Tên ứng dụng")
+                                        .expand_width()
+                                        .lens(UIDataAdapter::new_en_app),
+                                    3.0,
+                                )
+                                .with_flex_child(
+                                    Button::new("Thêm").on_click(|ctx, _, _| {
+                                        ctx.submit_command(ADD_EN_APP.to(Target::Global))
+                                    }),
+                                    1.0,
+                                )
+                                .expand_width()
+                                .border(Color::GRAY, 0.5),
+                        )
+                        .expand()
+                        .padding(4.0),
+                    1.0,
+                )
+                .expand(),
+            1.0,
+        )
+        .with_child(
+            Flex::row()
+                .with_child(
+                    Button::new("Đóng")
+                        .on_click(|ctx, _, _| ctx.window().close())
+                        .fix_width(100.0)
+                        .fix_height(28.0),
+                )
+                .main_axis_alignment(druid::widget::MainAxisAlignment::End)
+                .expand_width()
+                .padding(6.0),
+        )
+        .must_fill_main_axis(true)
+        .expand()
+        .padding(8.0)
 }
 
 pub fn center_window_position() -> (f64, f64) {


### PR DESCRIPTION
## Summary

Adds a new **"Danh sách ứng dụng"** (App List) window so users can add/remove apps from the Vietnamese and English app lists directly from the UI, without having to manually edit `~/.goxkey`.

## Changes

### `src/config.rs`
- Added `get_vn_apps()` and `get_en_apps()` to expose the app lists
- Added `remove_vietnamese_app()` and `remove_english_app()` to delete entries
- Fixed `add_vietnamese_app()` / `add_english_app()` to guard against duplicates

### `src/input.rs`
- Exposed `get_vn_apps()`, `get_en_apps()`, `add_vietnamese_app()`, `add_english_app()`, `remove_vietnamese_app()`, `remove_english_app()` on `InputState` — all delegating to `ConfigStore`

### `src/ui.rs`
- Added `AppEntry` struct (mirrors `MacroEntry` pattern)
- Added `vn_apps`, `en_apps`, `new_vn_app`, `new_en_app` fields to `UIDataAdapter`
- Added 4 new Selectors: `DELETE_VN_APP`, `DELETE_EN_APP`, `ADD_VN_APP`, `ADD_EN_APP`
- `UIController::event()` handles all 4 new selectors
- Added `app_row_item()` row widget factory (parameterized by delete selector)
- Added `app_settings_ui_builder()` — a two-column popup window (Vietnamese apps | English apps), each column has a scrollable list with `×` delete buttons and a TextBox + "Thêm" add button
- Added **"Danh sách ứng dụng"** button in `main_ui_builder()` below the auto-toggle checkbox row

## UI Preview (layout)

```
┌─────────────────────────────────────────┐
│           Danh sách ứng dụng            │
├────────────────────┬────────────────────┤
│ Ứng dụng tiếng Việt│ Ứng dụng tiếng Anh │
│ ┌────────────────┐ │ ┌────────────────┐ │
│ │ Zalo         × │ │ │ VSCode       × │ │
│ │ Messages     × │ │ │ Terminal     × │ │
│ └────────────────┘ │ └────────────────┘ │
│ [Tên ứng dụng][Thêm] [Tên ứng dụng][Thêm]│
├─────────────────────────────────────────┤
│                               [ Đóng ] │
└─────────────────────────────────────────┘
```