### PR TITLE
feat: Implement mixed Telex + VNI mode

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -126,6 +126,7 @@ pub fn rebuild_keyboard_layout_map() {
 pub enum TypingMethod {
     VNI,
     Telex,
+    TelexVNI,
 }
 
 impl FromStr for TypingMethod {
@@ -134,6 +135,7 @@ impl FromStr for TypingMethod {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_ascii_lowercase().as_str() {
             "vni" => TypingMethod::VNI,
+            "telexvni" => TypingMethod::TelexVNI,
             _ => TypingMethod::Telex,
         })
     }
@@ -147,6 +149,7 @@ impl Display for TypingMethod {
             match self {
                 Self::VNI => "vni",
                 Self::Telex => "telex",
+                Self::TelexVNI => "telexvni",
             }
         )
     }
@@ -374,9 +377,29 @@ impl InputState {
     }
 
     pub fn transform_keys(&self) -> Result<(String, TransformResult), ()> {
+        if self.method == TypingMethod::TelexVNI {
+            // Try both methods; prefer VNI when the buffer contains digits
+            // (VNI's key differentiator), otherwise fall back to Telex.
+            let buffer = self.buffer.clone();
+            let result = std::panic::catch_unwind(move || {
+                let has_digits = buffer.chars().any(|c| c.is_ascii_digit());
+                if has_digits {
+                    let mut output = String::new();
+                    let transform_result = vi::vni::transform_buffer(buffer.chars(), &mut output);
+                    (output, transform_result)
+                } else {
+                    let mut output = String::new();
+                    let transform_result =
+                        vi::telex::transform_buffer(buffer.chars(), &mut output);
+                    (output, transform_result)
+                }
+            });
+            return result.map_err(|_| ());
+        }
+
         let transform_method = match self.method {
             TypingMethod::VNI => vi::vni::transform_buffer,
-            TypingMethod::Telex => vi::telex::transform_buffer,
+            TypingMethod::Telex | TypingMethod::TelexVNI => vi::telex::transform_buffer,
         };
         let result = std::panic::catch_unwind(|| {
             let mut output = String::new();

--- a/src/platform/macos_ext.rs
+++ b/src/platform/macos_ext.rs
@@ -35,6 +35,7 @@ pub enum SystemTrayMenuItemKey {
     Enable,
     TypingMethodTelex,
     TypingMethodVNI,
+    TypingMethodTelexVNI,
     Exit,
 }
 
@@ -85,6 +86,7 @@ impl SystemTray {
         self.add_menu_separator();
         self.add_menu_item("Telex ✓", || ());
         self.add_menu_item("VNI", || ());
+        self.add_menu_item("Telex+VNI", || ());
         self.add_menu_separator();
         self.add_menu_item("Thoát ứng dụng", || ());
     }
@@ -119,7 +121,8 @@ impl SystemTray {
             SystemTrayMenuItemKey::Enable => 2,
             SystemTrayMenuItemKey::TypingMethodTelex => 4,
             SystemTrayMenuItemKey::TypingMethodVNI => 5,
-            SystemTrayMenuItemKey::Exit => 7,
+            SystemTrayMenuItemKey::TypingMethodTelexVNI => 6,
+            SystemTrayMenuItemKey::Exit => 8,
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,7 +31,7 @@ const ADD_EN_APP: Selector = Selector::new("gox-ui.add-en-app");
 const SET_VN_APP_FROM_PICKER: Selector<String> = Selector::new("gox-ui.set-vn-app-from-picker");
 const SET_EN_APP_FROM_PICKER: Selector<String> = Selector::new("gox-ui.set-en-app-from-picker");
 pub const WINDOW_WIDTH: f64 = 335.0;
-pub const WINDOW_HEIGHT: f64 = 420.0;
+pub const WINDOW_HEIGHT: f64 = 455.0;
 
 pub fn format_letter_key(c: Option<char>) -> String {
     if let Some(c) = c {
@@ -206,6 +206,7 @@ impl UIDataAdapter {
                         match self.typing_method {
                             TypingMethod::Telex => "gox",
                             TypingMethod::VNI => "go4",
+                            TypingMethod::TelexVNI => "go+",
                         }
                     } else {
                         "EN"
@@ -221,12 +222,24 @@ impl UIDataAdapter {
                         .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelex, "Telex");
                     self.systray
                         .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodVNI, "VNI ✓");
+                    self.systray
+                        .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelexVNI, "Telex+VNI");
                 }
                 TypingMethod::Telex => {
                     self.systray
                         .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelex, "Telex ✓");
                     self.systray
                         .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodVNI, "VNI");
+                    self.systray
+                        .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelexVNI, "Telex+VNI");
+                }
+                TypingMethod::TelexVNI => {
+                    self.systray
+                        .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelex, "Telex");
+                    self.systray
+                        .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodVNI, "VNI");
+                    self.systray
+                        .set_menu_item_title(SystemTrayMenuItemKey::TypingMethodTelexVNI, "Telex+VNI ✓");
                 }
             }
         }
@@ -261,6 +274,15 @@ impl UIDataAdapter {
             .set_menu_item_callback(SystemTrayMenuItemKey::TypingMethodVNI, || {
                 unsafe {
                     INPUT_STATE.set_method(TypingMethod::VNI);
+                }
+                UI_EVENT_SINK
+                    .get()
+                    .map(|event| Some(event.submit_command(UPDATE_UI, (), Target::Auto)));
+            });
+        self.systray
+            .set_menu_item_callback(SystemTrayMenuItemKey::TypingMethodTelexVNI, || {
+                unsafe {
+                    INPUT_STATE.set_method(TypingMethod::TelexVNI);
                 }
                 UI_EVENT_SINK
                     .get()
@@ -438,6 +460,7 @@ pub fn main_ui_builder() -> impl Widget<UIDataAdapter> {
                                 RadioGroup::column(vec![
                                     ("Telex", TypingMethod::Telex),
                                     ("VNI", TypingMethod::VNI),
+                                    ("Telex+VNI", TypingMethod::TelexVNI),
                                 ])
                                 .lens(UIDataAdapter::typing_method),
                             )


### PR DESCRIPTION
Implement a mixed Telex + VNI mode, so you can type whatever way you want.

Handled at client layer, so no changes needed in vi-rs.

<img width="185" height="231" alt="image" src="https://github.com/user-attachments/assets/2a04a4ca-60a4-4235-bb7a-f30b07de91d3" />

<img width="448" height="600" alt="image" src="https://github.com/user-attachments/assets/abb215b2-62c2-408e-a901-a7651128de43" />
