### PR TITLE
feat: add expansion import/export, auto-capitalize, and tooltip

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct ConfigStore {
     vn_apps: Vec<String>,
     en_apps: Vec<String>,
     is_macro_enabled: bool,
+    is_macro_autocap_enabled: bool,
     macro_table: BTreeMap<String, String>,
     is_auto_toggle_enabled: bool,
     is_gox_mode_enabled: bool,
@@ -34,7 +35,7 @@ fn parse_vec_string(line: String) -> Vec<String> {
         .collect()
 }
 
-fn parse_kv_string(line: &str) -> Option<(String, String)> {
+pub(crate) fn parse_kv_string(line: &str) -> Option<(String, String)> {
     if let Some((left, right)) = line.split_once("\"=\"") {
         let left = left.strip_prefix("\"").map(|s| s.replace("\\\"", "\""));
         let right = right.strip_suffix("\"").map(|s| s.replace("\\\"", "\""));
@@ -43,7 +44,7 @@ fn parse_kv_string(line: &str) -> Option<(String, String)> {
     return None;
 }
 
-fn build_kv_string(k: &str, v: &str) -> String {
+pub(crate) fn build_kv_string(k: &str, v: &str) -> String {
     format!(
         "\"{}\"=\"{}\"",
         k.replace("\"", "\\\""),
@@ -81,6 +82,11 @@ impl ConfigStore {
             "{} = {}",
             MACRO_ENABLED_CONFIG_KEY, self.is_macro_enabled
         )?;
+        writeln!(
+            file,
+            "{} = {}",
+            MACRO_AUTOCAP_ENABLED_CONFIG_KEY, self.is_macro_autocap_enabled
+        )?;
         for (k, v) in self.macro_table.iter() {
             writeln!(file, "{} = {}", MACROS_CONFIG_KEY, build_kv_string(k, &v))?;
         }
@@ -104,6 +110,7 @@ impl ConfigStore {
             vn_apps: Vec::new(),
             en_apps: Vec::new(),
             is_macro_enabled: false,
+            is_macro_autocap_enabled: false,
             macro_table: BTreeMap::new(),
             is_auto_toggle_enabled: false,
             is_gox_mode_enabled: false,
@@ -130,6 +137,9 @@ impl ConfigStore {
                         }
                         MACRO_ENABLED_CONFIG_KEY => {
                             config.is_macro_enabled = matches!(right.trim(), "true")
+                        }
+                        MACRO_AUTOCAP_ENABLED_CONFIG_KEY => {
+                            config.is_macro_autocap_enabled = matches!(right.trim(), "true")
                         }
                         MACROS_CONFIG_KEY => {
                             if let Some((k, v)) = parse_kv_string(right) {
@@ -257,6 +267,15 @@ impl ConfigStore {
         self.save();
     }
 
+    pub fn is_macro_autocap_enabled(&self) -> bool {
+        self.is_macro_autocap_enabled
+    }
+
+    pub fn set_macro_autocap_enabled(&mut self, flag: bool) {
+        self.is_macro_autocap_enabled = flag;
+        self.save();
+    }
+
     pub fn get_macro_table(&self) -> &BTreeMap<String, String> {
         &self.macro_table
     }
@@ -282,6 +301,7 @@ const TYPING_METHOD_CONFIG_KEY: &str = "method";
 const VN_APPS_CONFIG_KEY: &str = "vn-apps";
 const EN_APPS_CONFIG_KEY: &str = "en-apps";
 const MACRO_ENABLED_CONFIG_KEY: &str = "is_macro_enabled";
+const MACRO_AUTOCAP_ENABLED_CONFIG_KEY: &str = "is_macro_autocap_enabled";
 const AUTOS_TOGGLE_ENABLED_CONFIG_KEY: &str = "is_auto_toggle_enabled";
 const MACROS_CONFIG_KEY: &str = "macros";
 const GOX_MODE_CONFIG_KEY: &str = "is_gox_mode_enabled";

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,6 +40,40 @@ pub const STOP_TRACKING_WORDS: [&str; 4] = [";", "'", "?", "/"];
 /// engine ignores (falls through to `_ => Transformation::Ignored`), then restore them
 /// after transformation. A 'w' is "standalone" when NOT preceded by a Horn/Breve-eligible
 /// vowel — those cases (uw→ư, ow→ơ, aw→ă) should still be handled by telex normally.
+enum CapPattern {
+    Lower,
+    TitleCase,
+    AllCaps,
+}
+
+fn detect_cap_pattern(s: &str) -> CapPattern {
+    let mut chars = s.chars().filter(|c| c.is_alphabetic());
+    match chars.next() {
+        Some(first) if first.is_uppercase() => {
+            if chars.all(|c| c.is_uppercase()) {
+                CapPattern::AllCaps
+            } else {
+                CapPattern::TitleCase
+            }
+        }
+        _ => CapPattern::Lower,
+    }
+}
+
+fn apply_cap_pattern(s: &str, pattern: CapPattern) -> String {
+    match pattern {
+        CapPattern::Lower => s.to_string(),
+        CapPattern::AllCaps => s.to_uppercase(),
+        CapPattern::TitleCase => {
+            let mut chars = s.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().to_string() + chars.as_str(),
+            }
+        }
+    }
+}
+
 fn mask_standalone_w(buffer: &str) -> String {
     // Characters that can accept Horn (w) modification: u, o and all their toned forms.
     // Characters that can accept Breve (w) modification: a and all its toned forms.
@@ -195,6 +229,7 @@ pub struct InputState {
     previous_word: String,
     active_app: String,
     is_macro_enabled: bool,
+    is_macro_autocap_enabled: bool,
     macro_table: BTreeMap<String, String>,
     temporary_disabled: bool,
     previous_modifiers: KeyModifier,
@@ -216,6 +251,7 @@ impl InputState {
             previous_word: String::new(),
             active_app: String::new(),
             is_macro_enabled: config.is_macro_enabled(),
+            is_macro_autocap_enabled: config.is_macro_autocap_enabled(),
             macro_table: config.get_macro_table().clone(),
             temporary_disabled: false,
             previous_modifiers: KeyModifier::empty(),
@@ -285,11 +321,35 @@ impl InputState {
         self.should_track = true;
     }
 
-    pub fn get_macro_target(&self) -> Option<&String> {
+    pub fn get_macro_target(&self) -> Option<String> {
         if !self.is_macro_enabled {
             return None;
         }
-        self.macro_table.get(&self.display_buffer)
+        // Exact match
+        if let Some(target) = self.macro_table.get(&self.display_buffer) {
+            return Some(target.clone());
+        }
+        // Auto-capitalize: try lowercase lookup, then apply cap pattern
+        if self.is_macro_autocap_enabled {
+            let lower = self.display_buffer.to_lowercase();
+            if let Some(target) = self.macro_table.get(&lower) {
+                let pattern = detect_cap_pattern(&self.display_buffer);
+                return Some(apply_cap_pattern(target, pattern));
+            }
+        }
+        None
+    }
+
+    pub fn is_macro_autocap_enabled(&self) -> bool {
+        self.is_macro_autocap_enabled
+    }
+
+    pub fn toggle_macro_autocap(&mut self) {
+        self.is_macro_autocap_enabled = !self.is_macro_autocap_enabled;
+        CONFIG_MANAGER
+            .lock()
+            .unwrap()
+            .set_macro_autocap_enabled(self.is_macro_autocap_enabled);
     }
 
     pub fn get_typing_buffer(&self) -> &str {
@@ -411,6 +471,38 @@ impl InputState {
             .unwrap()
             .add_macro(from.clone(), to.clone());
         self.macro_table.insert(from, to);
+    }
+
+    pub fn export_macros_to_file(&self, path: &str) -> std::io::Result<()> {
+        use crate::config::build_kv_string;
+        use std::fs::File;
+        use std::io::Write;
+        let mut file = File::create(path)?;
+        for (k, v) in &self.macro_table {
+            writeln!(file, "{}", build_kv_string(k, v))?;
+        }
+        Ok(())
+    }
+
+    pub fn import_macros_from_file(&mut self, path: &str) -> std::io::Result<usize> {
+        use crate::config::parse_kv_string;
+        use std::fs::File;
+        use std::io::{BufRead, BufReader};
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut count = 0;
+        for line in reader.lines() {
+            let line = line?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some((from, to)) = parse_kv_string(line) {
+                self.add_macro(from, to);
+                count += 1;
+            }
+        }
+        Ok(count)
     }
 
     pub fn should_transform_keys(&self, c: &char) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn event_handler(
                                     if keycode == KEY_TAB || keycode == KEY_SPACE {
                                         if let Some(macro_target) = INPUT_STATE.get_macro_target() {
                                             debug!("Macro: {}", macro_target);
-                                            do_macro_replace(handle, macro_target)
+                                            do_macro_replace(handle, &macro_target)
                                         }
                                     }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -19,6 +19,8 @@ use core_graphics::{
 use objc::{class, msg_send, sel, sel_impl};
 
 pub use macos_ext::defer_open_app_file_picker;
+pub use macos_ext::defer_open_text_file_picker;
+pub use macos_ext::defer_save_text_file_picker;
 pub use macos_ext::SystemTray;
 pub use macos_ext::SystemTrayMenuItemKey;
 use once_cell::sync::Lazy;

--- a/src/platform/macos_ext.rs
+++ b/src/platform/macos_ext.rs
@@ -419,6 +419,83 @@ pub fn open_app_file_picker() -> Option<String> {
     }
 }
 
+pub fn open_text_file_picker() -> Option<String> {
+    unsafe {
+        let panel: id = msg_send![class!(NSOpenPanel), openPanel];
+        let _: () = msg_send![panel, setCanChooseFiles: YES];
+        let _: () = msg_send![panel, setCanChooseDirectories: NO];
+        let _: () = msg_send![panel, setAllowsMultipleSelection: NO as BOOL];
+
+        let response: i64 = msg_send![panel, runModal];
+        if response == 1 {
+            let url: id = msg_send![panel, URL];
+            let path: id = msg_send![url, path];
+            let utf8: *const std::ffi::c_char = msg_send![path, UTF8String];
+            if !utf8.is_null() {
+                return Some(
+                    std::ffi::CStr::from_ptr(utf8)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+        }
+        None
+    }
+}
+
+pub fn save_text_file_picker() -> Option<String> {
+    unsafe {
+        let panel: id = msg_send![class!(NSSavePanel), savePanel];
+        let suggested_name = NSString::alloc(nil).init_str("expansions.txt");
+        let _: () = msg_send![panel, setNameFieldStringValue: suggested_name];
+
+        let response: i64 = msg_send![panel, runModal];
+        if response == 1 {
+            let url: id = msg_send![panel, URL];
+            let path: id = msg_send![url, path];
+            let utf8: *const std::ffi::c_char = msg_send![path, UTF8String];
+            if !utf8.is_null() {
+                return Some(
+                    std::ffi::CStr::from_ptr(utf8)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+        }
+        None
+    }
+}
+
+pub fn defer_open_text_file_picker(callback: Box<dyn FnOnce(Option<String>) + Send>) {
+    unsafe extern "C" fn work(ctx: *mut c_void) {
+        let callback = Box::from_raw(ctx as *mut Box<dyn FnOnce(Option<String>) + Send>);
+        let path = open_text_file_picker();
+        callback(path);
+    }
+
+    let boxed: Box<Box<dyn FnOnce(Option<String>) + Send>> = Box::new(callback);
+    let ctx_ptr = Box::into_raw(boxed) as *mut c_void;
+
+    unsafe {
+        dispatch_async_f(&_dispatch_main_q, ctx_ptr, work);
+    }
+}
+
+pub fn defer_save_text_file_picker(callback: Box<dyn FnOnce(Option<String>) + Send>) {
+    unsafe extern "C" fn work(ctx: *mut c_void) {
+        let callback = Box::from_raw(ctx as *mut Box<dyn FnOnce(Option<String>) + Send>);
+        let path = save_text_file_picker();
+        callback(path);
+    }
+
+    let boxed: Box<Box<dyn FnOnce(Option<String>) + Send>> = Box::new(callback);
+    let ctx_ptr = Box::into_raw(boxed) as *mut c_void;
+
+    unsafe {
+        dispatch_async_f(&_dispatch_main_q, ctx_ptr, work);
+    }
+}
+
 pub fn add_app_change_callback<F>(cb: F)
 where
     F: Fn() + Send + 'static,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,10 +7,10 @@ use std::fmt::Display;
 
 use bitflags::bitflags;
 pub use os::{
-    add_app_change_callback, defer_open_app_file_picker, ensure_accessibility_permission,
-    get_active_app_name, get_home_dir, is_in_text_selection, is_launch_on_login,
-    run_event_listener, send_backspace, send_string, update_launch_on_login, Handle, SYMBOL_ALT,
-    SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
+    add_app_change_callback, defer_open_app_file_picker, defer_open_text_file_picker,
+    defer_save_text_file_picker, ensure_accessibility_permission, get_active_app_name, get_home_dir,
+    is_in_text_selection, is_launch_on_login, run_event_listener, send_backspace, send_string,
+    update_launch_on_login, Handle, SYMBOL_ALT, SYMBOL_CTRL, SYMBOL_SHIFT, SYMBOL_SUPER,
 };
 
 #[cfg(target_os = "macos")]

--- a/src/ui/controllers.rs
+++ b/src/ui/controllers.rs
@@ -1,6 +1,6 @@
 use crate::{
     input::{rebuild_keyboard_layout_map, INPUT_STATE},
-    platform::{update_launch_on_login, KeyModifier},
+    platform::{defer_open_text_file_picker, defer_save_text_file_picker, update_launch_on_login, KeyModifier},
 };
 use druid::{Env, Event, EventCtx, Screen, UpdateCtx, Widget, WindowDesc, WindowLevel};
 use log::error;
@@ -10,9 +10,9 @@ use super::{
     data::UIDataAdapter,
     format_letter_key, letter_key_to_char,
     selectors::{
-        ADD_MACRO, DELETE_MACRO, DELETE_SELECTED_APP, DELETE_SELECTED_MACRO,
-        RESET_DEFAULTS, SAVE_SHORTCUT, SET_EN_APP_FROM_PICKER, SHOW_ADD_MACRO_DIALOG,
-        SHOW_EDIT_SHORTCUT_DIALOG, TOGGLE_APP_MODE,
+        ADD_MACRO, DELETE_MACRO, DELETE_SELECTED_APP, DELETE_SELECTED_MACRO, EXPORT_MACROS_TO_FILE,
+        LOAD_MACROS_FROM_FILE, RESET_DEFAULTS, SAVE_SHORTCUT, SET_EN_APP_FROM_PICKER,
+        SHOW_ADD_MACRO_DIALOG, SHOW_EDIT_SHORTCUT_DIALOG, TOGGLE_APP_MODE,
     },
     SHOW_UI, UPDATE_UI, ADD_MACRO_DIALOG_HEIGHT, ADD_MACRO_DIALOG_WIDTH,
     EDIT_SHORTCUT_DIALOG_HEIGHT, EDIT_SHORTCUT_DIALOG_WIDTH,
@@ -142,6 +142,34 @@ impl<W: Widget<UIDataAdapter>> druid::widget::Controller<UIDataAdapter, W> for U
                         data.update();
                     }
                 }
+                if cmd.get(LOAD_MACROS_FROM_FILE).is_some() {
+                    ctx.set_handled();
+                    let event_sink = unsafe { crate::UI_EVENT_SINK.get().cloned() };
+                    defer_open_text_file_picker(Box::new(move |path| {
+                        if let Some(path) = path {
+                            unsafe {
+                                let _ = INPUT_STATE.import_macros_from_file(&path);
+                            }
+                            if let Some(sink) = event_sink {
+                                let _ = sink.submit_command(crate::ui::UPDATE_UI, (), druid::Target::Global);
+                            }
+                        }
+                    }));
+                }
+                if cmd.get(EXPORT_MACROS_TO_FILE).is_some() {
+                    ctx.set_handled();
+                    let event_sink = unsafe { crate::UI_EVENT_SINK.get().cloned() };
+                    defer_save_text_file_picker(Box::new(move |path| {
+                        if let Some(path) = path {
+                            unsafe {
+                                let _ = INPUT_STATE.export_macros_to_file(&path);
+                            }
+                            if let Some(sink) = event_sink {
+                                let _ = sink.submit_command(crate::ui::UPDATE_UI, (), druid::Target::Global);
+                            }
+                        }
+                    }));
+                }
                 if cmd.get(DELETE_SELECTED_APP).is_some() {
                     let idx = data.selected_app_index;
                     if idx >= 0 {
@@ -231,6 +259,10 @@ impl<W: Widget<UIDataAdapter>> druid::widget::Controller<UIDataAdapter, W> for U
 
             if old_data.is_macro_enabled != data.is_macro_enabled {
                 INPUT_STATE.toggle_macro_enabled();
+            }
+
+            if old_data.is_macro_autocap_enabled != data.is_macro_autocap_enabled {
+                INPUT_STATE.toggle_macro_autocap();
             }
 
             if old_data.is_auto_toggle_enabled != data.is_auto_toggle_enabled {

--- a/src/ui/data.rs
+++ b/src/ui/data.rs
@@ -30,6 +30,7 @@ pub struct UIDataAdapter {
     pub(super) is_w_literal_enabled: bool,
     // Macro config
     pub(super) is_macro_enabled: bool,
+    pub(super) is_macro_autocap_enabled: bool,
     pub(super) macro_table: Arc<Vec<MacroEntry>>,
     pub(super) new_macro_from: String,
     pub(super) new_macro_to: String,
@@ -71,6 +72,7 @@ impl UIDataAdapter {
             is_auto_toggle_enabled: false,
             is_w_literal_enabled: false,
             is_macro_enabled: false,
+            is_macro_autocap_enabled: false,
             macro_table: Arc::new(Vec::new()),
             new_macro_from: String::new(),
             new_macro_to: String::new(),
@@ -105,6 +107,7 @@ impl UIDataAdapter {
             self.typing_method = INPUT_STATE.get_method();
             self.hotkey_display = INPUT_STATE.get_hotkey().to_string();
             self.is_macro_enabled = INPUT_STATE.is_macro_enabled();
+            self.is_macro_autocap_enabled = INPUT_STATE.is_macro_autocap_enabled();
             self.is_auto_toggle_enabled = INPUT_STATE.is_auto_toggle_enabled();
             self.is_w_literal_enabled = INPUT_STATE.is_w_literal_enabled();
             self.launch_on_login = is_launch_on_login();

--- a/src/ui/selectors.rs
+++ b/src/ui/selectors.rs
@@ -13,3 +13,5 @@ pub(super) const SHOW_EDIT_SHORTCUT_DIALOG: Selector =
 pub(super) const SAVE_SHORTCUT: Selector<(bool, bool, bool, bool, String)> =
     Selector::new("gox-ui.save-shortcut");
 pub(super) const RESET_DEFAULTS: Selector = Selector::new("gox-ui.reset-defaults");
+pub(super) const LOAD_MACROS_FROM_FILE: Selector = Selector::new("gox-ui.load-macros-from-file");
+pub(super) const EXPORT_MACROS_TO_FILE: Selector = Selector::new("gox-ui.export-macros-to-file");

--- a/src/ui/views.rs
+++ b/src/ui/views.rs
@@ -1,4 +1,8 @@
-use crate::{input::TypingMethod, platform::defer_open_app_file_picker, UI_EVENT_SINK};
+use crate::{
+    input::TypingMethod,
+    platform::{defer_open_app_file_picker, defer_open_text_file_picker, defer_save_text_file_picker},
+    UI_EVENT_SINK,
+};
 use druid::{
     kurbo::RoundedRect,
     piet::{FontFamily, Text, TextLayout, TextLayoutBuilder},
@@ -18,11 +22,12 @@ use super::{
     data::{MacroEntry, UIDataAdapter},
     selectors::{
         ADD_MACRO, DELETE_MACRO, DELETE_SELECTED_APP, DELETE_SELECTED_MACRO,
-        SET_EN_APP_FROM_PICKER, SHOW_ADD_MACRO_DIALOG, SHOW_EDIT_SHORTCUT_DIALOG,
+        EXPORT_MACROS_TO_FILE, LOAD_MACROS_FROM_FILE, SET_EN_APP_FROM_PICKER,
+        SHOW_ADD_MACRO_DIALOG, SHOW_EDIT_SHORTCUT_DIALOG,
     },
     widgets::{
-        AppsListWidget, HotkeyBadgesWidget, MacroListWidget, SegmentedControl, ShortcutCaptureWidget,
-        StyledCheckbox, TabBar, ToggleSwitch,
+        AppsListWidget, HotkeyBadgesWidget, InfoTooltip, MacroListWidget, SegmentedControl,
+        ShortcutCaptureWidget, StyledCheckbox, TabBar, ToggleSwitch,
     },
     WINDOW_HEIGHT, WINDOW_WIDTH,
 };
@@ -569,6 +574,53 @@ fn advanced_tab() -> impl Widget<UIDataAdapter> {
         ToggleSwitch.lens(UIDataAdapter::is_macro_enabled),
     ));
 
+    let autocap_row = settings_card(
+        Flex::row()
+            .with_flex_child(
+                Flex::column()
+                    .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+                    .with_child(
+                        Painter::new(|ctx, _: &UIDataAdapter, _| {
+                            let layout = ctx
+                                .text()
+                                .new_text_layout("Auto capitalize")
+                                .font(FontFamily::SYSTEM_UI, 13.0)
+                                .text_color(TEXT_PRIMARY)
+                                .build()
+                                .unwrap();
+                            ctx.draw_text(&layout, (0.0, 0.0));
+                        })
+                        .fix_height(18.0)
+                        .expand_width(),
+                    )
+                    .with_child(
+                        Painter::new(|ctx, _: &UIDataAdapter, _| {
+                            let layout = ctx
+                                .text()
+                                .new_text_layout("Apply capitalization from typed shorthand")
+                                .font(FontFamily::SYSTEM_UI, 12.0)
+                                .text_color(TEXT_SECONDARY)
+                                .build()
+                                .unwrap();
+                            ctx.draw_text(&layout, (0.0, 0.0));
+                        })
+                        .fix_height(16.0)
+                        .expand_width(),
+                    ),
+                1.0,
+            )
+            .with_child(
+                InfoTooltip::new("ko → không\nKo → Không\nKO → KHÔNG")
+                    .padding((0.0, 0.0, 8.0, 0.0)),
+            )
+            .with_child(StyledCheckbox.lens(UIDataAdapter::is_macro_autocap_enabled))
+            .cross_axis_alignment(druid::widget::CrossAxisAlignment::Center)
+            .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
+            .must_fill_main_axis(true)
+            .expand_width()
+            .padding((14.0, 10.0)),
+    );
+
     let macro_list = {
         let mut scroll = Scroll::new(MacroListWidget::new().expand_width());
         scroll.set_enabled_scrollbars(druid::scroll_component::ScrollbarsEnabled::Vertical);
@@ -629,6 +681,51 @@ fn advanced_tab() -> impl Widget<UIDataAdapter> {
         }
     });
 
+    let load_btn = Painter::new(|ctx, _: &UIDataAdapter, _| {
+        let size = ctx.size();
+        ctx.fill(Rect::new(size.width - 0.5, 10.0, size.width, size.height - 10.0), &DIVIDER);
+        let layout = ctx
+            .text()
+            .new_text_layout("Load")
+            .font(FontFamily::SYSTEM_UI, 12.0)
+            .text_color(TEXT_PRIMARY)
+            .build()
+            .unwrap();
+        ctx.draw_text(
+            &layout,
+            (
+                (size.width - layout.size().width) / 2.0,
+                (size.height - layout.size().height) / 2.0,
+            ),
+        );
+    })
+    .fix_size(60.0, 44.0)
+    .on_click(|ctx, _data: &mut UIDataAdapter, _| {
+        ctx.submit_command(LOAD_MACROS_FROM_FILE.to(Target::Global));
+    });
+
+    let export_btn = Painter::new(|ctx, _: &UIDataAdapter, _| {
+        let size = ctx.size();
+        let layout = ctx
+            .text()
+            .new_text_layout("Export")
+            .font(FontFamily::SYSTEM_UI, 12.0)
+            .text_color(TEXT_PRIMARY)
+            .build()
+            .unwrap();
+        ctx.draw_text(
+            &layout,
+            (
+                (size.width - layout.size().width) / 2.0,
+                (size.height - layout.size().height) / 2.0,
+            ),
+        );
+    })
+    .fix_size(60.0, 44.0)
+    .on_click(|ctx, _data: &mut UIDataAdapter, _| {
+        ctx.submit_command(EXPORT_MACROS_TO_FILE.to(Target::Global));
+    });
+
     let card = Container::new(
         Flex::column()
             .with_flex_child(macro_list.expand(), 1.0)
@@ -645,6 +742,15 @@ fn advanced_tab() -> impl Widget<UIDataAdapter> {
                     .with_child(add_btn)
                     .with_child(remove_btn)
                     .with_flex_spacer(1.0)
+                    .with_child(
+                        Painter::new(|ctx, _: &UIDataAdapter, _| {
+                            let h = ctx.size().height;
+                            ctx.fill(Rect::new(0.0, 10.0, 0.5, h - 10.0), &DIVIDER);
+                        })
+                        .fix_size(0.5, 44.0),
+                    )
+                    .with_child(load_btn)
+                    .with_child(export_btn)
                     .expand_width(),
             ),
     )
@@ -657,6 +763,8 @@ fn advanced_tab() -> impl Widget<UIDataAdapter> {
         .with_child(description)
         .with_spacer(12.0)
         .with_child(enable_row)
+        .with_spacer(8.0)
+        .with_child(autocap_row)
         .with_spacer(16.0)
         .with_flex_child(card.expand_height(), 1.0)
         .must_fill_main_axis(true)

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -138,6 +138,91 @@ impl Widget<bool> for StyledCheckbox {
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
+// InfoTooltip
+// ══════════════════════════════════════════════════════════════════════════════
+
+pub(super) struct InfoTooltip {
+    text: &'static str,
+    is_hovered: bool,
+}
+
+impl InfoTooltip {
+    pub fn new(text: &'static str) -> Self {
+        Self { text, is_hovered: false }
+    }
+}
+
+impl<T: druid::Data> Widget<T> for InfoTooltip {
+    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
+        if let LifeCycle::HotChanged(hot) = event {
+            self.is_hovered = *hot;
+            // Invalidate both the widget rect and the tooltip area above it.
+            // Tooltip is rendered at negative y (above the widget) via paint_with_z_index,
+            // so the repaint region must cover that area or it won't be cleared.
+            ctx.request_paint_rect(Rect::new(-260.0, -100.0, 20.0, 20.0));
+        }
+    }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, _bc: &BoxConstraints, _data: &T, _env: &Env) -> Size {
+        // Tell Druid this widget paints outside its layout bounds (tooltip above/left).
+        // This propagates up through parent widgets (Padding, Flex, Container) so
+        // the parent's paint_insets expand to include the tooltip area, allowing
+        // request_paint_rect with negative coords to survive merge_up clipping.
+        ctx.set_paint_insets(druid::Insets::new(260.0, 100.0, 0.0, 0.0));
+        Size::new(18.0, 18.0)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, _env: &Env) {
+        let size = ctx.size();
+        let cx = size.width / 2.0;
+        let cy = size.height / 2.0;
+        let circle = Circle::new((cx, cy), 8.0);
+        ctx.stroke(circle, &TEXT_SECONDARY, 1.0);
+        let layout = ctx
+            .text()
+            .new_text_layout("?")
+            .font(FontFamily::SYSTEM_UI, 11.0)
+            .text_color(TEXT_SECONDARY)
+            .build()
+            .unwrap();
+        ctx.draw_text(
+            &layout,
+            (cx - layout.size().width / 2.0, cy - layout.size().height / 2.0),
+        );
+
+        if self.is_hovered {
+            let tooltip_text = self.text;
+            ctx.paint_with_z_index(10, move |ctx| {
+                let text_layout = ctx
+                    .text()
+                    .new_text_layout(tooltip_text)
+                    .font(FontFamily::SYSTEM_UI, 12.0)
+                    .text_color(Color::WHITE)
+                    .max_width(240.0)
+                    .build()
+                    .unwrap();
+                let text_size = text_layout.size();
+                let padding = 8.0;
+                let box_w = text_size.width + padding * 2.0;
+                let box_h = text_size.height + padding * 2.0;
+                // Widget-local coords: (0,0) is this widget's top-left.
+                // Right-align tooltip to the icon's right edge (18px wide),
+                // and place it above the icon with a small gap.
+                let box_x = 18.0 - box_w;
+                let box_y = -box_h - 4.0;
+                let bg_rect = RoundedRect::new(box_x, box_y, box_x + box_w, box_y + box_h, 6.0);
+                ctx.fill(bg_rect, &Color::rgb8(40, 40, 40));
+                ctx.draw_text(&text_layout, (box_x + padding, box_y + padding));
+            });
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
 // SegmentedControl
 // ══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION

<img width="480" height="652" alt="image" src="https://github.com/user-attachments/assets/60718739-1aa7-4efd-8153-a08440150bb2" />

Text Expansion tab improvements:

- Load from file / Export to file: native macOS NSOpenPanel/NSSavePanel file pickers; macros serialized in the same "key"="value" format used internally by ~/.goxkey. Import merges with existing entries.

- Auto capitalize (checkbox): when enabled, a typed shorthand whose casing differs from the stored key is looked up case-insensitively and the replacement is re-cased to match — ko→không, Ko→Không, KO→KHÔNG. Setting persisted to config as is_macro_autocap_enabled.

- InfoTooltip widget: hovering the ⓘ icon next to the checkbox shows a dark rounded popup with the capitalization example. Fixed two bugs that prevented the tooltip from showing/hiding correctly:
  1. Coordinate system: paint_with_z_index closure operates in widget-local coords, not window coords — removed incorrect to_window() offset.
  2. Repaint region: set_paint_insets(260, 100, 0, 0) declared in layout() so the tooltip area survives merge_up clipping and is included in the window invalid region on hover enter/leave.