### PR TITLE
Remove Globe (Fn) key from auto switching language

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use platform::{
     ensure_accessibility_permission, run_event_listener, send_arrow_left, send_arrow_right,
     send_backspace, send_string, EventTapType, Handle, KeyModifier, PressedKey, KEY_DELETE,
     KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_TAB, RAW_ARROW_DOWN, RAW_ARROW_LEFT, RAW_ARROW_RIGHT,
-    RAW_ARROW_UP, RAW_KEY_GLOBE,
+    RAW_ARROW_UP,
 };
 use ui::{get_theme, UIDataAdapter, IS_DARK, THEME, UPDATE_UI};
 
@@ -285,10 +285,6 @@ fn event_handler(
             Some(pressed_key) => {
                 match pressed_key {
                     PressedKey::Raw(raw_keycode) => {
-                        if raw_keycode == RAW_KEY_GLOBE {
-                            toggle_vietnamese();
-                            return true;
-                        }
                         if raw_keycode == RAW_ARROW_UP || raw_keycode == RAW_ARROW_DOWN {
                             INPUT_STATE.new_word();
                         }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -20,7 +20,6 @@ pub use os::{
 pub use os::SystemTray;
 pub use os::SystemTrayMenuItemKey;
 
-pub const RAW_KEY_GLOBE: u16 = 0xb3;
 pub const RAW_ARROW_DOWN: u16 = 0x7d;
 pub const RAW_ARROW_UP: u16 = 0x7e;
 pub const RAW_ARROW_LEFT: u16 = 0x7b;


### PR DESCRIPTION
I am using Fn key for other purposes and it conflicts with goxkey at the moment. Since we already have the shortcut to switch language, I hope removing its functionality makes sense here.

Let me know if this is intentional to default to Fn key for language switching, alternatively, we can add a toggle in Setting UI for this too.